### PR TITLE
Sitemaps : more robust parsing of XML elements

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -570,10 +570,7 @@ public class SiteMapParser {
         NodeList list = elem.getElementsByTagName(elementName);
         Element e = (Element) list.item(0);
         if (e != null) {
-            NodeList children = e.getChildNodes();
-            if (children.item(0) != null) {
-                return ((Node) children.item(0)).getNodeValue().trim();
-            }
+            return e.getTextContent();
         }
 
         return null;

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -284,7 +284,7 @@ public class SiteMapParserTest {
                 .append("  <priority>0.3</priority>")
                 .append("</url>")
                 .append("<url>")
-                .append("  <loc>http://www.example.com/catalog?item=83&amp;desc=vacation_usa</loc>")
+                .append("  <loc><url><![CDATA[http://www.example.com/catalog?item=83&amp;desc=vacation_usa]]></url></loc>")
                 .append("  <lastmod>2004-11-23</lastmod>")
                 .append("</url>")
                 .append("</urlset>");


### PR DESCRIPTION
This patch simplifies the logic of extracting textual values from elements such as `loc`. At the moment it throws a NPE if the first child element does not have a value as in the example below \: 

[http://jobs.optistaffing.com/sitemap.xml]

```
<url>
<loc>
<url>
<![CDATA[
http://jobs.optistaffing.com/EXPERIENCED-DISPATCHER-NEEDED-NOW----Jobs-in-Vancouver-WA/2333221
]]>
</url>
</loc>
<lastmod>2015-04-28</lastmod>
<changefreq>daily</changefreq>
</url>
```

at least we should handle this more gracefully and check that `children.item(0)).getNodeValue()` is not null.

This PR uses a more generic approach for extracting the textual content of a node which also has the added benefit of extracting correctly from the cases above where the content is slightly incorrect e.g. additional url element within the loc. 
