### PR TITLE
Parse XML sitemaps via SAX for option to parse partial/broken documents

### DIFF
--- a/crawler-commons.iml
+++ b/crawler-commons.iml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module org.jetbrains.idea.maven.project.MavenProjectsManager.isMavenModule="true" type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" LANGUAGE_LEVEL="JDK_1_6" inherit-compiler-output="false">
+    <output url="file://$MODULE_DIR$/target/classes" />
+    <output-test url="file://$MODULE_DIR$/target/test-classes" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/resources" type="java-resource" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/java" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/src/test/resources" type="java-test-resource" />
+      <excludeFolder url="file://$MODULE_DIR$/target" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpclient:4.3.5" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.httpcomponents:httpcore:4.3.2" level="project" />
+    <orderEntry type="library" name="Maven: commons-logging:commons-logging:1.1.3" level="project" />
+    <orderEntry type="library" name="Maven: commons-codec:commons-codec:1.6" level="project" />
+    <orderEntry type="library" name="Maven: commons-io:commons-io:2.4" level="project" />
+    <orderEntry type="library" name="Maven: org.apache.tika:tika-core:1.8" level="project" />
+    <orderEntry type="library" name="Maven: org.slf4j:slf4j-api:1.7.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: junit:junit:4.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.slf4j:slf4j-log4j12:1.7.7" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: log4j:log4j:1.2.17" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.mockito:mockito-core:1.8.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.hamcrest:hamcrest-core:1.1" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: org.objenesis:objenesis:1.0" level="project" />
+    <orderEntry type="library" scope="TEST" name="Maven: jetty:jetty:5.1.10" level="project" />
+    <orderEntry type="library" scope="PROVIDED" name="Maven: javax.servlet:servlet-api:2.5" level="project" />
+  </component>
+</module>

--- a/src/main/java/crawlercommons/sitemaps/AbstractSiteMapSAXHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/AbstractSiteMapSAXHandler.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package crawlercommons.sitemaps;
+
+import java.net.URL;
+import java.util.LinkedList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+import org.xml.sax.helpers.DefaultHandler;
+
+/**
+ * Provides a base SAX handler for parsing of XML documents representing
+ * sub-classes of AbstractSiteMap.
+ */
+public class AbstractSiteMapSAXHandler extends DefaultHandler {
+
+    private LinkedList<String> elementStack;
+    private AbstractSiteMapSAXHandler delegate;
+    private URL url;
+    private boolean strict;
+    private UnknownFormatException exception;
+
+    protected AbstractSiteMapSAXHandler(LinkedList<String> elementStack, boolean strict) {
+        this.elementStack = elementStack;
+        this.strict = strict;
+    }
+
+    public AbstractSiteMapSAXHandler(URL url, boolean strict) {
+        this.elementStack = new LinkedList<String>();
+        this.url = url;
+        this.strict = strict;
+    }
+
+    protected URL getUrl() {
+        return url;
+    }
+
+    protected boolean isStrict() {
+        return strict;
+    }
+
+    protected void setException(UnknownFormatException exception) {
+        this.exception = exception;
+    }
+
+    protected UnknownFormatException getException() {
+        return exception;
+    }
+
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        if (elementStack.isEmpty()) {
+            startRootElement(uri, localName, qName, attributes);
+        } else {
+            elementStack.push(qName);
+        }
+    }
+
+    private void startRootElement(String uri, String localName, String qName, Attributes attributes) {
+        elementStack.push(qName);
+        if ("sitemapindex".equals(qName)) {
+            delegate = new SiteMapIndexSAXHandler(url, elementStack, strict);
+        } else if ("urlset".equals(qName)) {
+            delegate = new SiteMapSAXHandler(url, elementStack, strict);
+        } else if ("feed".equals(qName)) {
+            delegate = new SiteMapAtomSAXHandler(url, elementStack, strict);
+        } else if ("rss".equals(qName)) {
+            delegate = new SiteMapRSSSAXHandler(url, elementStack, strict);
+        }
+    }
+
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        delegate.endElement(uri, localName, qName);
+        elementStack.pop();
+    }
+
+    public void characters(char ch[], int start, int length) throws SAXException {
+        if (delegate != null) {
+            delegate.characters(ch, start, length);
+        }
+    }
+
+    protected String currentElement() {
+        return elementStack.peek();
+    }
+
+    protected String currentElementParent() {
+        return (elementStack.size() < 2) ? null : elementStack.get(1);
+    }
+
+    public AbstractSiteMap getSiteMap() {
+        return delegate.getSiteMap();
+    }
+
+    public void error(SAXParseException e) throws SAXException {
+        if (delegate != null) {
+            delegate.error(e);
+        }
+    }
+
+    public void fatalError(SAXParseException e) throws SAXException {
+        if (delegate != null) {
+            delegate.fatalError(e);
+        }
+    }
+}

--- a/src/main/java/crawlercommons/sitemaps/SiteMapAtomSAXHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapAtomSAXHandler.java
@@ -1,0 +1,127 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package crawlercommons.sitemaps;
+
+import static crawlercommons.sitemaps.SiteMapParser.LOG;
+import static crawlercommons.sitemaps.SiteMapParser.urlIsLegal;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+
+/**
+ * Parse the XML document which is assumed to be in Atom format. Atom 1.0
+ * example:
+ * 
+ * <?xml version="1.0" encoding="utf-8"?> <feed
+ * xmlns="http://www.w3.org/2005/Atom">
+ * 
+ * <title>Example Feed</title> <subtitle>A subtitle.</subtitle> <link
+ * href="http://example.org/feed/" rel="self"/> <link
+ * href="http://example.org/"/> <modified>2003-12-13T18:30:02Z</modified>
+ * <author> <name>John Doe</name> <email>johndoe@example.com</email> </author>
+ * <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
+ * 
+ * <entry> <title>Atom-Powered Robots Run Amok</title> <link
+ * href="http://example.org/2003/12/13/atom03"/>
+ * <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+ * <updated>2003-12-13T18:30:02Z</updated> <summary>Some text.</summary>
+ * </entry>
+ * 
+ * </feed>
+ */
+class SiteMapAtomSAXHandler extends AbstractSiteMapSAXHandler {
+
+    private SiteMap sitemap;
+    private URL loc;
+    private String lastMod;
+    boolean valid;
+    private int i = 0;
+
+    SiteMapAtomSAXHandler(URL url, LinkedList<String> elementStack, boolean strict) {
+        super(elementStack, strict);
+        sitemap = new SiteMap(url);
+        sitemap.setType(SitemapType.ATOM);
+    }
+
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+        if ("entry".equals(localName)) {
+            loc = null;
+            lastMod = null;
+        } else if ("link".equals(localName)) {
+            String href = attributes.getValue("href");
+            LOG.debug("href = {}", href);
+            try {
+                loc = new URL(href);
+                valid = urlIsLegal(sitemap.getBaseUrl(), href);
+            } catch (MalformedURLException e) {
+                LOG.trace("Can't create an entry with a bad URL", e);
+                LOG.debug("Bad url: [{}]", href);
+            }
+        }
+    }
+
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        if ("entry".equals(currentElement())) {
+            maybeAddSiteMapUrl();
+        } else if ("feed".equals(currentElement())) {
+            sitemap.setProcessed(true);
+        }
+    }
+
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        String qName = super.currentElement();
+        String value = String.valueOf(ch, start, length);
+        if ("updated".equals(qName)) {
+            lastMod = value;
+        }
+    }
+
+    public AbstractSiteMap getSiteMap() {
+        return sitemap;
+    }
+
+    private void maybeAddSiteMapUrl() {
+        if (valid || !isStrict()) {
+            if (loc == null) {
+                LOG.debug("Missing url");
+                LOG.trace("Can't create an entry with a missing URL");
+            } else {
+                SiteMapURL sUrl = new SiteMapURL(loc.toString(), lastMod, null, null, valid);
+                sitemap.addSiteMapUrl(sUrl);
+                LOG.debug("  {}. {}", (++i), sUrl);
+            }
+        }
+        loc = null;
+        lastMod = null;
+    }
+
+    public void error(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+
+    public void fatalError(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+
+}

--- a/src/main/java/crawlercommons/sitemaps/SiteMapIndexSAXHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapIndexSAXHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package crawlercommons.sitemaps;
+
+import static crawlercommons.sitemaps.SiteMapParser.LOG;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Date;
+import java.util.LinkedList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+
+/**
+ * Parse XML that contains a Sitemap Index. Example Sitemap Index:
+ * 
+ * <?xml version="1.0" encoding="UTF-8"?> <sitemapindex
+ * xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> <sitemap>
+ * <loc>http://www.example.com/sitemap1.xml.gz</loc>
+ * <lastmod>2004-10-01T18:23:17+00:00</lastmod> </sitemap> <sitemap>
+ * <loc>http://www.example.com/sitemap2.xml.gz</loc>
+ * <lastmod>2005-01-01</lastmod> </sitemap> </sitemapindex>
+ * 
+ */
+class SiteMapIndexSAXHandler extends AbstractSiteMapSAXHandler {
+
+    private SiteMapIndex sitemap;
+    private URL loc;
+    private Date lastMod;
+    private int i = 0;
+
+    SiteMapIndexSAXHandler(URL url, LinkedList<String> elementStack, boolean strict) {
+        super(elementStack, strict);
+        sitemap = new SiteMapIndex(url);
+        sitemap.setType(SitemapType.INDEX);
+    }
+
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+    }
+
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        if ("sitemap".equals(currentElement())) {
+            maybeAddSiteMap();
+        } else if ("sitemapindex".equals(currentElement())) {
+            sitemap.setProcessed(true);
+        }
+    }
+
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        String localName = super.currentElement();
+        String value = String.valueOf(ch, start, length);
+        if ("loc".equals(localName)) {
+            try {
+                loc = new URL(value);
+            } catch (MalformedURLException e) {
+                LOG.trace("Don't create an entry with a bad URL", e);
+                LOG.debug("Bad url: [{}]", loc);
+            }
+        } else if ("lastmod".equals(localName)) {
+            lastMod = SiteMap.convertToDate(value);
+            ;
+        }
+    }
+
+    public AbstractSiteMap getSiteMap() {
+        return sitemap;
+    }
+
+    private void maybeAddSiteMap() {
+        if (loc != null) {
+            SiteMap s = new SiteMap(loc, lastMod);
+            sitemap.addSitemap(s);
+            LOG.debug("  {}. {}", (i + 1), s);
+        }
+        loc = null;
+        lastMod = null;
+    }
+
+    public void error(SAXParseException e) throws SAXException {
+        maybeAddSiteMap();
+    }
+
+    public void fatalError(SAXParseException e) throws SAXException {
+        maybeAddSiteMap();
+    }
+}

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -17,6 +17,9 @@
 
 package crawlercommons.sitemaps;
 
+import static org.apache.tika.mime.MediaType.APPLICATION_XML;
+import static org.apache.tika.mime.MediaType.TEXT_PLAIN;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -26,11 +29,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.zip.GZIPInputStream;
 
-import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParser;
+import javax.xml.parsers.SAXParserFactory;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
@@ -40,15 +44,10 @@ import org.apache.tika.mime.MediaType;
 import org.apache.tika.mime.MediaTypeRegistry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.w3c.dom.Document;
-import org.w3c.dom.Element;
-import org.w3c.dom.Node;
-import org.w3c.dom.NodeList;
 import org.xml.sax.InputSource;
+import org.xml.sax.SAXException;
 
 import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
-import static org.apache.tika.mime.MediaType.APPLICATION_XML;
-import static org.apache.tika.mime.MediaType.TEXT_PLAIN;
 
 public class SiteMapParser {
     public static final Logger LOG = LoggerFactory.getLogger(SiteMapParser.class);
@@ -66,21 +65,30 @@ public class SiteMapParser {
     private final static List<MediaType> XML_MEDIA_TYPES = new ArrayList<MediaType>();
     private final static List<MediaType> TEXT_MEDIA_TYPES = new ArrayList<MediaType>();
     private final static List<MediaType> GZ_MEDIA_TYPES = new ArrayList<MediaType>();
+    
     static {
         initMediaTypes();
     }
 
     /** True (by default) if invalid URLs should be rejected */
     private boolean strict;
+    /** False (by default) if partial/incomplete documents should still be processed */
+    private boolean allowPartial;
 
     public SiteMapParser() {
-        this(true);
+        this(true, false);
     }
 
-    public SiteMapParser(boolean strict) {
-        this.strict = strict;
+
+	public SiteMapParser(boolean strict) {
+        this(strict, false);
     }
 
+	public SiteMapParser(boolean strict, boolean allowPartial) {
+		this.strict = strict;
+		this.allowPartial = allowPartial;
+	}
+	
     /**
      * @return whether invalid URLs will be rejected
      */
@@ -184,8 +192,9 @@ public class SiteMapParser {
 
         return processXml(sitemapUrl, is);
     }
+    
 
-    /**
+	/**
      * Process a text-based Sitemap. Text sitemaps only list URLs but no
      * priorities, last mods, etc.
      * 
@@ -266,349 +275,33 @@ public class SiteMapParser {
      */
     private AbstractSiteMap processXml(URL sitemapUrl, InputSource is) throws UnknownFormatException {
 
-        Document doc = null;
-
+        SAXParserFactory factory = SAXParserFactory.newInstance();
+        AbstractSiteMapSAXHandler handler = new AbstractSiteMapSAXHandler(sitemapUrl, strict);
         try {
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            doc = dbf.newDocumentBuilder().parse(is);
-        } catch (Exception e) {
-            LOG.debug(e.toString());
-            throw new UnknownFormatException("Error parsing XML for: " + sitemapUrl);
-        }
-
-        // See if this is a sitemap index
-        NodeList nodeList = doc.getElementsByTagName("sitemapindex");
-        if (nodeList.getLength() > 0) {
-            nodeList = doc.getElementsByTagName("sitemap");
-            return parseSitemapIndex(sitemapUrl, nodeList);
-        } else if (doc.getElementsByTagName("urlset").getLength() > 0) {
-            // This is a regular Sitemap
-            return parseXmlSitemap(sitemapUrl, doc);
-        } else if (doc.getElementsByTagName("link").getLength() > 0) {
-            // Could be RSS or Atom
-            return parseSyndicationFormat(sitemapUrl, doc);
-        }
-
-        throw new UnknownFormatException("Unknown XML format for: " + sitemapUrl);
-    }
-
-    /**
-     * Parse XML that contains a valid Sitemap. Example of a Sitemap: <?xml
-     * version="1.0" encoding="UTF-8"?> <urlset
-     * xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> <url>
-     * <loc>http://www.example.com/</loc> <lastmod>2005-01-01</lastmod>
-     * <changefreq>monthly</changefreq> <priority>0.8</priority> </url> <url>
-     * <loc
-     * >http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
-     * <changefreq>weekly</changefreq> </url> </urlset>
-     * 
-     * @param doc
-     */
-    private SiteMap parseXmlSitemap(URL sitemapUrl, Document doc) {
-
-        SiteMap sitemap = new SiteMap(sitemapUrl);
-        sitemap.setType(SitemapType.XML);
-
-        NodeList list = doc.getElementsByTagName("url");
-
-        // Loop through the <url>s
-        for (int i = 0; i < list.getLength(); i++) {
-
-            Node n = list.item(i);
-            if (n.getNodeType() == Node.ELEMENT_NODE) {
-                Element elem = (Element) n;
-
-                String loc = getElementValue(elem, "loc");
-                try {
-                    URL url = new URL(loc);
-                    String lastMod = getElementValue(elem, "lastmod");
-                    String changeFreq = getElementValue(elem, "changefreq");
-                    String priority = getElementValue(elem, "priority");
-                    boolean valid = urlIsLegal(sitemap.getBaseUrl(), url.toString());
-
-                    if (valid || !strict) {
-                        SiteMapURL sUrl = new SiteMapURL(url.toString(), lastMod, changeFreq, priority, valid);
-                        sitemap.addSiteMapUrl(sUrl);
-                        LOG.debug("  {}. {}", (i + 1), sUrl);
-                    }
-                } catch (MalformedURLException e) {
-                    LOG.debug("Bad url: [{}]", loc);
-                    LOG.trace("Can't create an entry with a bad URL", e);
-                }
-            }
-        }
-        sitemap.setProcessed(true);
-        return sitemap;
-    }
-
-    /**
-     * Parse XML that contains a Sitemap Index. Example Sitemap Index:
-     * 
-     * <?xml version="1.0" encoding="UTF-8"?> <sitemapindex
-     * xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> <sitemap>
-     * <loc>http://www.example.com/sitemap1.xml.gz</loc>
-     * <lastmod>2004-10-01T18:23:17+00:00</lastmod> </sitemap> <sitemap>
-     * <loc>http://www.example.com/sitemap2.xml.gz</loc>
-     * <lastmod>2005-01-01</lastmod> </sitemap> </sitemapindex>
-     * 
-     * @param url
-     *            - URL of Sitemap Index
-     * @param nodeList
-     */
-    private SiteMapIndex parseSitemapIndex(URL url, NodeList nodeList) {
-
-        LOG.debug("Parsing Sitemap Index");
-
-        SiteMapIndex sitemapIndex = new SiteMapIndex(url);
-        sitemapIndex.setType(SitemapType.INDEX);
-
-        // Loop through the <sitemap>s
-        for (int i = 0; i < nodeList.getLength() && i < MAX_URLS; i++) {
-
-            Node firstNode = nodeList.item(i);
-
-            if (firstNode.getNodeType() == Node.ELEMENT_NODE) {
-                Element elem = (Element) firstNode;
-                String loc = getElementValue(elem, "loc");
-
-                // try the text content when no loc element
-                // has been specified
-                if (loc == null) {
-                    loc = elem.getTextContent().trim();
-                }
-
-                try {
-                    URL sitemapUrl = new URL(loc);
-                    String lastmod = getElementValue(elem, "lastmod");
-                    Date lastModified = SiteMap.convertToDate(lastmod);
-
-                    // Right now we are not worried about sitemapUrls that point
-                    // to different websites.
-
-                    SiteMap s = new SiteMap(sitemapUrl, lastModified);
-                    sitemapIndex.addSitemap(s);
-                    LOG.debug("  {}. {}", (i + 1), s);
-                } catch (MalformedURLException e) {
-                    LOG.trace("Don't create an entry with a bad URL", e);
-                    LOG.debug("Bad url: [{}]", loc);
-                }
-            }
-        }
-        sitemapIndex.setProcessed(true);
-        return sitemapIndex;
-    }
-
-    /**
-     * Parse the XML document, looking for a <b>feed</b> element to determine if
-     * it's an <b>Atom doc</b> <b>rss</b> to determine if it's an <b>RSS
-     * doc</b>.
-     * 
-     * @param sitemapUrl
-     * @param doc
-     *            - XML document to parse
-     * @throws UnknownFormatException
-     *             if XML does not appear to be Atom or RSS
-     */
-    private SiteMap parseSyndicationFormat(URL sitemapUrl, Document doc) throws UnknownFormatException {
-
-        SiteMap sitemap = new SiteMap(sitemapUrl);
-
-        // See if this is an Atom feed by looking for "feed" element
-        NodeList list = doc.getElementsByTagName("feed");
-        if (list.getLength() > 0) {
-            parseAtom(sitemap, (Element) list.item(0), doc);
-            sitemap.setProcessed(true);
-            return sitemap;
-        } else {
-            // See if it is a RSS feed by looking for a "rss" element
-            list = doc.getElementsByTagName("rss");
-            if (list.getLength() > 0) {
-                parseRSS(sitemap, doc);
+            SAXParser saxParser = factory.newSAXParser();
+            saxParser.parse(is, handler);
+            return handler.getSiteMap();
+        } catch (IOException e) {
+            UnknownFormatException ufe = new UnknownFormatException("Failed to parse " + sitemapUrl);
+            ufe.initCause(e);
+            throw ufe;
+        } catch (SAXException e) {
+            if (allowPartial) {
+                LOG.warn("Processed broken/partial sitemap for '" + sitemapUrl + "'");
+                AbstractSiteMap sitemap = handler.getSiteMap();
                 sitemap.setProcessed(true);
                 return sitemap;
             } else {
-                throw new UnknownFormatException("Unknown syndication format at " + sitemapUrl);
+                UnknownFormatException ufe = new UnknownFormatException("Failed to parse " + sitemapUrl);
+                ufe.initCause(e);
+                throw ufe;
             }
+        } catch (ParserConfigurationException e) {
+            throw new IllegalStateException(e);
         }
     }
-
-    /**
-     * Parse the XML document which is assumed to be in Atom format. Atom 1.0
-     * example:
-     * 
-     * <?xml version="1.0" encoding="utf-8"?> <feed
-     * xmlns="http://www.w3.org/2005/Atom">
-     * 
-     * <title>Example Feed</title> <subtitle>A subtitle.</subtitle> <link
-     * href="http://example.org/feed/" rel="self"/> <link
-     * href="http://example.org/"/> <modified>2003-12-13T18:30:02Z</modified>
-     * <author> <name>John Doe</name> <email>johndoe@example.com</email>
-     * </author> <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
-     * 
-     * <entry> <title>Atom-Powered Robots Run Amok</title> <link
-     * href="http://example.org/2003/12/13/atom03"/>
-     * <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
-     * <updated>2003-12-13T18:30:02Z</updated> <summary>Some text.</summary>
-     * </entry>
-     * 
-     * </feed>
-     * 
-     * @param elem
-     * @param doc
-     */
-    private void parseAtom(SiteMap sitemap, Element elem, Document doc) {
-
-        // Grab items from <feed><entry><link href="URL" /></entry></feed>
-        // Use lastmod date from <feed><modified>DATE</modified></feed>
-
-        LOG.debug("Parsing Atom XML");
-
-        sitemap.setType(SitemapType.ATOM);
-
-        String lastMod = getElementValue(elem, "modified");
-        LOG.debug("lastMod = {}", lastMod);
-
-        NodeList list = doc.getElementsByTagName("entry");
-
-        // Loop through the <entry>s
-        for (int i = 0; i < list.getLength() && i < MAX_URLS; i++) {
-
-            Node n = list.item(i);
-            if (n.getNodeType() == Node.ELEMENT_NODE) {
-                elem = (Element) n;
-
-                String href = getElementAttributeValue(elem, "link", "href");
-                LOG.debug("href = {}", href);
-
-                try {
-                    URL url = new URL(href);
-                    boolean valid = urlIsLegal(sitemap.getBaseUrl(), url.toString());
-
-                    if (valid || !strict) {
-                        SiteMapURL sUrl = new SiteMapURL(url.toString(), lastMod, null, null, valid);
-                        sitemap.addSiteMapUrl(sUrl);
-                        LOG.debug("  {}. {}", (i + 1), sUrl);
-                    }
-                } catch (MalformedURLException e) {
-                    LOG.trace("Can't create an entry with a bad URL", e);
-                    LOG.debug("Bad url: [{}]", href);
-                }
-            }
-        }
-    }
-
-    /**
-     * Parse XML document which is assumed to be in RSS format. RSS 2.0 example:
-     * 
-     * <?xml version="1.0"?> <rss version="2.0"> <channel> <title>Lift Off
-     * News</title> <link>http://liftoff.msfc.nasa.gov/</link>
-     * <description>Liftoff to Space Exploration.</description>
-     * <language>en-us</language> <pubDate>Tue, 10 Jun 2003 04:00:00
-     * GMT</pubDate> <lastBuildDate>Tue, 10 Jun 2003 09:41:01
-     * GMT</lastBuildDate> <docs>http://blogs.law.harvard.edu/tech/rss</docs>
-     * <generator>Weblog Editor 2.0</generator>
-     * <managingEditor>editor@example.com</managingEditor>
-     * <webMaster>webmaster@example.com</webMaster> <ttl>5</ttl>
-     * 
-     * <item> <title>Star City</title>
-     * <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
-     * <description>How do Americans get ready to work with Russians aboard the
-     * International Space Station? They take a crash course in culture,
-     * language and protocol at Russia's Star City.</description> <pubDate>Tue,
-     * 03 Jun 2003 09:39:21 GMT</pubDate>
-     * <guid>http://liftoff.msfc.nasa.gov/2003/06/03.html#item573</guid> </item>
-     * 
-     * <item> <title>Space Exploration</title>
-     * <link>http://liftoff.msfc.nasa.gov/</link> <description>Sky watchers in
-     * Europe, Asia, and parts of Alaska and Canada will experience a partial
-     * eclipse of the Sun on Saturday, May 31.</description> <pubDate>Fri, 30
-     * May 2003 11:06:42 GMT</pubDate>
-     * <guid>http://liftoff.msfc.nasa.gov/2003/05/30.html#item572</guid> </item>
-     * 
-     * </channel> </rss>
-     * 
-     * @param sitemap
-     * @param doc
-     */
-    private void parseRSS(SiteMap sitemap, Document doc) {
-
-        // Grab items from <item><link>URL</link></item>
-        // and last modified date from <pubDate>DATE</pubDate>
-
-        LOG.debug("Parsing RSS doc");
-        sitemap.setType(SitemapType.RSS);
-        NodeList list = doc.getElementsByTagName("channel");
-        Element elem = (Element) list.item(0);
-
-        // Treat publication date as last mod (Tue, 10 Jun 2003 04:00:00 GMT)
-        String lastMod = getElementValue(elem, "pubDate");
-        LOG.debug("lastMod = ", lastMod);
-
-        list = doc.getElementsByTagName("item");
-        // Loop through the <item>s
-        for (int i = 0; i < list.getLength() && i < MAX_URLS; i++) {
-
-            Node n = list.item(i);
-            if (n.getNodeType() == Node.ELEMENT_NODE) {
-                elem = (Element) n;
-                String link = getElementValue(elem, "link");
-                LOG.debug("link = {}", link);
-
-                try {
-                    URL url = new URL(link);
-                    boolean valid = urlIsLegal(sitemap.getBaseUrl(), url.toString());
-
-                    if (valid || !strict) {
-                        SiteMapURL sUrl = new SiteMapURL(url.toString(), lastMod, null, null, valid);
-                        sitemap.addSiteMapUrl(sUrl);
-                        LOG.debug("  {}. {}", (i + 1), sUrl);
-                    }
-                } catch (MalformedURLException e) {
-                    LOG.trace("Can't create an entry with a bad URL", e);
-                    LOG.debug("Bad url: [{}]", link);
-                }
-            }
-        }
-    }
-
-    /**
-     * Get the element's textual content.
-     * 
-     * @param elem
-     * @param elementName
-     * @return
-     */
-    private String getElementValue(Element elem, String elementName) {
-
-        NodeList list = elem.getElementsByTagName(elementName);
-        if (list == null)
-            return null;
-        Element e = (Element) list.item(0);
-        if (e != null) {
-            return e.getTextContent();
-        }
-        return null;
-    }
-
-    /**
-     * Get the element's attribute value.
-     * 
-     * @param elem
-     * @param elementName
-     * @param attributeName
-     * @return
-     */
-    private String getElementAttributeValue(Element elem, String elementName, String attributeName) {
-
-        NodeList list = elem.getElementsByTagName(elementName);
-        Element e = (Element) list.item(0);
-        if (e != null) {
-            return e.getAttribute(attributeName);
-        }
-
-        return null;
-    }
-
+    
+    
     /**
      * See if testUrl is under sitemapBaseUrl. Only URLs under sitemapBaseUrl
      * are legal. Both URLs are first converted to lowercase before the
@@ -619,7 +312,7 @@ public class SiteMapParser {
      * @param testUrl
      * @return true if testUrl is under sitemapBaseUrl, false otherwise
      */
-    private boolean urlIsLegal(String sitemapBaseUrl, String testUrl) {
+    static boolean urlIsLegal(String sitemapBaseUrl, String testUrl) {
 
         boolean ret = false;
 

--- a/src/main/java/crawlercommons/sitemaps/SiteMapRSSSAXHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapRSSSAXHandler.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package crawlercommons.sitemaps;
+
+import static crawlercommons.sitemaps.SiteMapParser.LOG;
+import static crawlercommons.sitemaps.SiteMapParser.urlIsLegal;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+
+/**
+ * Parse XML document which is assumed to be in RSS format. RSS 2.0 example:
+ * 
+ * <?xml version="1.0"?> <rss version="2.0"> <channel> <title>Lift Off
+ * News</title> <link>http://liftoff.msfc.nasa.gov/</link> <description>Liftoff
+ * to Space Exploration.</description> <language>en-us</language> <pubDate>Tue,
+ * 10 Jun 2003 04:00:00 GMT</pubDate> <lastBuildDate>Tue, 10 Jun 2003 09:41:01
+ * GMT</lastBuildDate> <docs>http://blogs.law.harvard.edu/tech/rss</docs>
+ * <generator>Weblog Editor 2.0</generator>
+ * <managingEditor>editor@example.com</managingEditor>
+ * <webMaster>webmaster@example.com</webMaster> <ttl>5</ttl>
+ * 
+ * <item> <title>Star City</title>
+ * <link>http://liftoff.msfc.nasa.gov/news/2003/news-starcity.asp</link>
+ * <description>How do Americans get ready to work with Russians aboard the
+ * International Space Station? They take a crash course in culture, language
+ * and protocol at Russia's Star City.</description> <pubDate>Tue, 03 Jun 2003
+ * 09:39:21 GMT</pubDate>
+ * <guid>http://liftoff.msfc.nasa.gov/2003/06/03.html#item573</guid> </item>
+ * 
+ * <item> <title>Space Exploration</title>
+ * <link>http://liftoff.msfc.nasa.gov/</link> <description>Sky watchers in
+ * Europe, Asia, and parts of Alaska and Canada will experience a partial
+ * eclipse of the Sun on Saturday, May 31.</description> <pubDate>Fri, 30 May
+ * 2003 11:06:42 GMT</pubDate>
+ * <guid>http://liftoff.msfc.nasa.gov/2003/05/30.html#item572</guid> </item>
+ * 
+ * </channel> </rss>
+ */
+class SiteMapRSSSAXHandler extends AbstractSiteMapSAXHandler {
+
+    private SiteMap sitemap;
+    private URL loc;
+    private String lastMod;
+    boolean valid;
+    private int i = 0;
+
+    SiteMapRSSSAXHandler(URL url, LinkedList<String> elementStack, boolean strict) {
+        super(elementStack, strict);
+        sitemap = new SiteMap(url);
+        sitemap.setType(SitemapType.RSS);
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * crawlercommons.sitemaps.AbstractSiteMapSAXHandler#startElement(java.lang
+     * .String, java.lang.String, java.lang.String, org.xml.sax.Attributes)
+     */
+    @Override
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see
+     * crawlercommons.sitemaps.AbstractSiteMapSAXHandler#endElement(java.lang
+     * .String, java.lang.String, java.lang.String)
+     */
+    @Override
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        if ("item".equals(currentElement())) {
+            maybeAddSiteMapUrl();
+        } else if ("rss".equals(currentElement())) {
+            sitemap.setProcessed(true);
+        }
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see crawlercommons.sitemaps.AbstractSiteMapSAXHandler#characters(char[],
+     * int, int)
+     */
+    @Override
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        String localName = super.currentElement();
+        String value = String.valueOf(ch, start, length);
+        if ("pubDate".equals(localName)) {
+            lastMod = value;
+        } else if ("link".equals(localName)) {
+            String href = value;
+            LOG.debug("href = {}", href);
+            try {
+                loc = new URL(href);
+                valid = urlIsLegal(sitemap.getBaseUrl(), href);
+            } catch (MalformedURLException e) {
+                LOG.trace("Can't create an entry with a bad URL", e);
+                LOG.debug("Bad url: [{}]", href);
+            }
+        }
+    }
+
+    public AbstractSiteMap getSiteMap() {
+        return sitemap;
+    }
+
+    private void maybeAddSiteMapUrl() {
+        if (valid || !isStrict()) {
+            if (loc == null) {
+                LOG.debug("Missing url");
+                LOG.trace("Can't create an entry with a missing URL");
+            } else {
+                SiteMapURL sUrl = new SiteMapURL(loc.toString(), lastMod, null, null, valid);
+                sitemap.addSiteMapUrl(sUrl);
+                LOG.debug("  {}. {}", (++i), sUrl);
+            }
+        }
+        loc = null;
+        lastMod = null;
+    }
+
+    public void error(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+
+    public void fatalError(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+}

--- a/src/main/java/crawlercommons/sitemaps/SiteMapSAXHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapSAXHandler.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package crawlercommons.sitemaps;
+
+import static crawlercommons.sitemaps.SiteMapParser.LOG;
+import static crawlercommons.sitemaps.SiteMapParser.urlIsLegal;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.LinkedList;
+
+import org.xml.sax.Attributes;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
+
+import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+
+/**
+ * Parse XML that contains a valid Sitemap. Example of a Sitemap: <?xml
+ * version="1.0" encoding="UTF-8"?> <urlset
+ * xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"> <url>
+ * <loc>http://www.example.com/</loc> <lastmod>2005-01-01</lastmod>
+ * <changefreq>monthly</changefreq> <priority>0.8</priority> </url> <url> <loc
+ * >http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii</loc>
+ * <changefreq>weekly</changefreq> </url> </urlset>
+ * 
+ * @author mdeboer
+ */
+class SiteMapSAXHandler extends AbstractSiteMapSAXHandler {
+
+    private SiteMap sitemap;
+    private URL loc;
+    private String lastMod;
+    private String changeFreq;
+    private String priority;
+    boolean valid;
+    private int i = 0;
+
+    SiteMapSAXHandler(URL url, LinkedList<String> elementStack, boolean strict) {
+        super(elementStack, strict);
+        sitemap = new SiteMap(url);
+        sitemap.setType(SitemapType.XML);
+    }
+
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
+    }
+
+    public void endElement(String uri, String localName, String qName) throws SAXException {
+        if ("url".equals(qName) && "urlset".equals(currentElementParent())) {
+            maybeAddSiteMapUrl();
+        } else if ("urlset".equals(qName)) {
+            sitemap.setProcessed(true);
+        }
+    }
+
+    public void characters(char[] ch, int start, int length) throws SAXException {
+        String qName = super.currentElement();
+        String value = String.valueOf(ch, start, length);
+        if ("loc".equals(qName) || "url".equals(qName)) {
+            try {
+                loc = new URL(value);
+                valid = urlIsLegal(sitemap.getBaseUrl(), value);
+            } catch (MalformedURLException e) {
+                LOG.debug("Bad url: [{}]", value);
+                LOG.trace("Can't create an entry with a bad URL", e);
+            }
+        } else if ("changefreq".equals(qName)) {
+            changeFreq = value;
+        } else if ("lastmod".equals(qName)) {
+            lastMod = value;
+        } else if ("priority".equals(qName)) {
+            priority = value;
+        }
+    }
+
+    public AbstractSiteMap getSiteMap() {
+        return sitemap;
+    }
+
+    private void maybeAddSiteMapUrl() {
+        if (valid || !isStrict()) {
+            if (loc == null) {
+                LOG.debug("Missing url");
+                LOG.trace("Can't create an entry with a missing URL");
+            } else {
+                SiteMapURL sUrl = new SiteMapURL(loc.toString(), lastMod, changeFreq, priority, valid);
+                sitemap.addSiteMapUrl(sUrl);
+                LOG.debug("  {}. {}", (++i), sUrl);
+            }
+        }
+        loc = null;
+        lastMod = null;
+        changeFreq = null;
+        priority = null;
+    }
+
+    public void error(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+
+    public void fatalError(SAXParseException e) throws SAXException {
+        maybeAddSiteMapUrl();
+    }
+}


### PR DESCRIPTION
Adds an additional optional constructor arg (false by default) which enables parsing of partial/broken xml-based sitemap documents.