### PR TITLE
handling of robots.txt with multiple matching user-agent lines

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -18,7 +18,6 @@
 package crawlercommons.robots;
 
 import java.io.UnsupportedEncodingException;
-import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
 import java.util.HashMap;

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -87,9 +87,24 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     }
 
     private static class ParseState {
+        /**
+         * Flag indicating whether the given name of the agent matched.
+         */
         private boolean _matchedRealName;
+        /**
+         * Flag that is true if not the given agent name but a wildcard matched.
+         */
         private boolean _matchedWildcard;
+        /**
+         * Flag that is true as long as it is allowed to add rules for the given
+         * agent.
+         */
         private boolean _addingRules;
+        /**
+         * Flag indicating whether all consecutive agent fields has been seen.
+         * It is set to false if an agent field is found and back to true if
+         * something else has been found.
+         */
         private boolean _finishedAgentFields;
 
         private String _url;
@@ -310,7 +325,8 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
         String encoding = "us-ascii";
 
         // Check for a UTF-8 BOM at the beginning (EF BB BF)
-        if ((bytesLen >= 3) && (content[0] == (byte) 0xEF) && (content[1] == (byte) 0xBB) && (content[2] == (byte) 0xBF)) {
+        if ((bytesLen >= 3) && (content[0] == (byte) 0xEF) && (content[1] == (byte) 0xBB)
+                && (content[2] == (byte) 0xBF)) {
             offset = 3;
             bytesLen -= 3;
             encoding = "UTF-8";
@@ -395,47 +411,48 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
 
             RobotToken token = tokenize(line);
             switch (token.getDirective()) {
-                case USER_AGENT:
+            case USER_AGENT:
                 keepGoing = handleUserAgent(parseState, token);
-                    break;
+                break;
 
-                case DISALLOW:
+            case DISALLOW:
                 keepGoing = handleDisallow(parseState, token);
-                    break;
+                break;
 
-                case ALLOW:
+            case ALLOW:
                 keepGoing = handleAllow(parseState, token);
-                    break;
+                break;
 
-                case CRAWL_DELAY:
+            case CRAWL_DELAY:
                 keepGoing = handleCrawlDelay(parseState, token);
-                    break;
+                break;
 
-                case SITEMAP:
+            case SITEMAP:
                 keepGoing = handleSitemap(parseState, token);
-                    break;
+                break;
 
-                case HTTP:
+            case HTTP:
                 keepGoing = handleHttp(parseState, token);
-                    break;
+                break;
 
-                case UNKNOWN:
+            case UNKNOWN:
                 reportWarning("Unknown directive in robots.txt file: " + line, url);
                 parseState.setFinishedAgentFields(true);
-                    break;
+                break;
 
-                case MISSING:
-                reportWarning(String.format("Unknown line in robots.txt file (size %d): %s", content.length, line), url);
+            case MISSING:
+                reportWarning(String.format("Unknown line in robots.txt file (size %d): %s", content.length, line),
+                        url);
                 parseState.setFinishedAgentFields(true);
-                    break;
+                break;
 
-                default:
-                    // All others we just ignore
-                    // TODO KKr - which of these should be setting
-                    // finishedAgentFields to true?
-                    // TODO KKr - handle no-index
-                    // TODO KKr - handle request-rate and visit-time
-                    break;
+            default:
+                // All others we just ignore
+                // TODO KKr - which of these should be setting
+                // finishedAgentFields to true?
+                // TODO KKr - handle no-index
+                // TODO KKr - handle request-rate and visit-time
+                break;
             }
         }
 
@@ -474,24 +491,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * @return true to keep going, false if we're done
      */
     private boolean handleUserAgent(ParseState state, RobotToken token) {
-        if (state.isMatchedRealName()) {
-            if (state.isFinishedAgentFields()) {
-                // We're all done.
-                return false;
-            } else {
-                // Skip any more of these, once we have a real name match. We're
-                // waiting for some
-                // allow/disallow/crawl delay fields.
-                return true;
-            }
-        }
-
+        // If the agent fields already have been finished before
         if (state.isFinishedAgentFields()) {
-            // We've got a user agent field, so we haven't yet seen anything
-            // that tells us
-            // we're done with this set of agent names.
-            state.setFinishedAgentFields(false);
+            // Before adding rules (again) we should watch for the agent name
             state.setAddingRules(false);
+            // we have found an agent field and their might come more
+            state.setFinishedAgentFields(false);
         }
 
         // Handle the case when there are multiple target names are passed
@@ -511,7 +516,9 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                 agentName = agentName.trim().toLowerCase();
                 if (agentName.isEmpty()) {
                     // Ignore empty names
-                } else if (agentName.equals("*") && !state.isMatchedWildcard()) {
+                } else if (agentName.equals("*") && !state.isMatchedRealName()) {
+                    // We have found a wildcard and didn't matched the real name
+                    // (until now)
                     state.setMatchedWildcard(true);
                     state.setAddingRules(true);
                 } else {
@@ -520,8 +527,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                         if (targetName.startsWith(agentName)) {
                             state.setMatchedRealName(true);
                             state.setAddingRules(true);
-                            state.clearRules(); // In case we previously hit a
-                                                // wildcard rule match
+                            if (state.isMatchedWildcard()) {
+                                state.setMatchedWildcard(false);
+                                state.clearRules(); // In case we previously hit
+                                                    // a
+                                                    // wildcard rule match
+                            }
                             break;
                         }
                     }

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -55,7 +55,8 @@ public class SimpleRobotRulesParserTest {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.cfm?fuseaction=sitesearch.results*";
 
         BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
-        assertFalse(rules.isAllowed("http://searchservice.domain.com/index.cfm?fuseaction=sitesearch.results&type=People&qry=california&pg=2"));
+        assertFalse(rules.isAllowed(
+                "http://searchservice.domain.com/index.cfm?fuseaction=sitesearch.results&type=People&qry=california&pg=2"));
     }
 
     @Test
@@ -150,8 +151,9 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testCommentedOutLines() throws MalformedURLException {
-        final String simpleRobotsTxt = "#user-agent: testAgent" + LF + LF + "#allow: /index.html" + LF + "#allow: /test" + LF + LF + "#user-agent: test" + LF + LF + "#allow: /index.html" + LF
-                        + "#disallow: /test" + LF + LF + "#user-agent: someAgent" + LF + LF + "#disallow: /index.html" + LF + "#disallow: /test" + LF + LF;
+        final String simpleRobotsTxt = "#user-agent: testAgent" + LF + LF + "#allow: /index.html" + LF + "#allow: /test"
+                + LF + LF + "#user-agent: test" + LF + LF + "#allow: /index.html" + LF + "#disallow: /test" + LF + LF
+                + "#user-agent: someAgent" + LF + LF + "#disallow: /index.html" + LF + "#disallow: /test" + LF + LF;
 
         BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
         Assert.assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
@@ -168,7 +170,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testAgentNotListed() throws MalformedURLException {
         // Access is assumed to be allowed, if no rules match an agent.
-        final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /"
+                + CRLF + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("crawler3", simpleRobotsTxt.getBytes());
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
@@ -193,9 +196,11 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testMixedEndings() throws MalformedURLException {
-        final String mixedEndingsRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF + "# comments to webmaster@fict.org" + CR + LF + "User-agent: unhipbot" + LF + "Disallow: /" + CR + ""
-                        + CRLF + "User-agent: webcrawler" + LF + "User-agent: excite" + CR + "Disallow: " + "\u0085" + CR + "User-agent: *" + CRLF + "Disallow: /org/plans.html" + LF + "Allow: /org/"
-                        + CR + "Allow: /serv" + CRLF + "Allow: /~mak" + LF + "Disallow: /" + CRLF;
+        final String mixedEndingsRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF
+                + "# comments to webmaster@fict.org" + CR + LF + "User-agent: unhipbot" + LF + "Disallow: /" + CR + ""
+                + CRLF + "User-agent: webcrawler" + LF + "User-agent: excite" + CR + "Disallow: " + "\u0085" + CR
+                + "User-agent: *" + CRLF + "Disallow: /org/plans.html" + LF + "Allow: /org/" + CR + "Allow: /serv"
+                + CRLF + "Allow: /~mak" + LF + "Disallow: /" + CRLF;
 
         BaseRobotRules rules;
 
@@ -222,9 +227,11 @@ public class SimpleRobotRulesParserTest {
     public void testRfpCases() throws MalformedURLException {
         // Run through all of the tests that are part of the robots.txt RFP
         // http://www.robotstxt.org/norobots-rfc.txt
-        final String rfpExampleRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF + "# comments to webmaster@fict.org" + CRLF + CRLF + "User-agent: unhipbot" + CRLF + "Disallow: /" + CRLF
-                        + "" + CRLF + "User-agent: webcrawler" + CRLF + "User-agent: excite" + CRLF + "Disallow: " + CRLF + CRLF + "User-agent: *" + CRLF + "Disallow: /org/plans.html" + CRLF
-                        + "Allow: /org/" + CRLF + "Allow: /serv" + CRLF + "Allow: /~mak" + CRLF + "Disallow: /" + CRLF;
+        final String rfpExampleRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF
+                + "# comments to webmaster@fict.org" + CRLF + CRLF + "User-agent: unhipbot" + CRLF + "Disallow: /"
+                + CRLF + "" + CRLF + "User-agent: webcrawler" + CRLF + "User-agent: excite" + CRLF + "Disallow: " + CRLF
+                + CRLF + "User-agent: *" + CRLF + "Disallow: /org/plans.html" + CRLF + "Allow: /org/" + CRLF
+                + "Allow: /serv" + CRLF + "Allow: /~mak" + CRLF + "Disallow: /" + CRLF;
 
         BaseRobotRules rules;
 
@@ -285,8 +292,10 @@ public class SimpleRobotRulesParserTest {
     public void testNutchCases() throws MalformedURLException {
         // Run through the Nutch test cases.
 
-        final String nutchRobotsTxt = "User-Agent: Agent1 #foo" + CR + "Disallow: /a" + CR + "Disallow: /b/a" + CR + "#Disallow: /c" + CR + "" + CR + "" + CR + "User-Agent: Agent2 Agent3#foo" + CR
-                        + "User-Agent: Agent4" + CR + "Disallow: /d" + CR + "Disallow: /e/d/" + CR + "" + CR + "User-Agent: *" + CR + "Disallow: /foo/bar/" + CR;
+        final String nutchRobotsTxt = "User-Agent: Agent1 #foo" + CR + "Disallow: /a" + CR + "Disallow: /b/a" + CR
+                + "#Disallow: /c" + CR + "" + CR + "" + CR + "User-Agent: Agent2 Agent3#foo" + CR + "User-Agent: Agent4"
+                + CR + "Disallow: /d" + CR + "Disallow: /e/d/" + CR + "" + CR + "User-Agent: *" + CR
+                + "Disallow: /foo/bar/" + CR;
 
         BaseRobotRules rules;
 
@@ -425,9 +434,10 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testHtmlMarkupInRobotsTxt() throws MalformedURLException {
-        final String htmlRobotsTxt = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\"><HTML>\n" + "<HEAD>\n" + "<TITLE>/robots.txt</TITLE>\n" + "</HEAD>\n" + "<BODY>\n"
-                        + "User-agent: anybot<BR>\n" + "Disallow: <BR>\n" + "Crawl-Delay: 10<BR>\n" + "\n" + "User-agent: *<BR>\n" + "Disallow: /<BR>\n" + "Crawl-Delay: 30<BR>\n" + "\n" + "</BODY>\n"
-                        + "</HTML>\n";
+        final String htmlRobotsTxt = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\"><HTML>\n" + "<HEAD>\n"
+                + "<TITLE>/robots.txt</TITLE>\n" + "</HEAD>\n" + "<BODY>\n" + "User-agent: anybot<BR>\n"
+                + "Disallow: <BR>\n" + "Crawl-Delay: 10<BR>\n" + "\n" + "User-agent: *<BR>\n" + "Disallow: /<BR>\n"
+                + "Crawl-Delay: 30<BR>\n" + "\n" + "</BODY>\n" + "</HTML>\n";
 
         BaseRobotRules rules;
 
@@ -451,9 +461,10 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testHeritrixCases() throws MalformedURLException {
-        final String heritrixRobotsTxt = "User-agent: *\n" + "Disallow: /cgi-bin/\n" + "Disallow: /details/software\n" + "\n" + "User-agent: denybot\n" + "Disallow: /\n" + "\n"
-                        + "User-agent: allowbot1\n" + "Disallow: \n" + "\n" + "User-agent: allowbot2\n" + "Disallow: /foo\n" + "Allow: /\n" + "\n" + "User-agent: delaybot\n" + "Disallow: /\n"
-                        + "Crawl-Delay: 20\n" + "Allow: /images/\n";
+        final String heritrixRobotsTxt = "User-agent: *\n" + "Disallow: /cgi-bin/\n" + "Disallow: /details/software\n"
+                + "\n" + "User-agent: denybot\n" + "Disallow: /\n" + "\n" + "User-agent: allowbot1\n" + "Disallow: \n"
+                + "\n" + "User-agent: allowbot2\n" + "Disallow: /foo\n" + "Allow: /\n" + "\n" + "User-agent: delaybot\n"
+                + "Disallow: /\n" + "Crawl-Delay: 20\n" + "Allow: /images/\n";
 
         BaseRobotRules rules;
         rules = createRobotRules("Mozilla allowbot1 99.9", heritrixRobotsTxt.getBytes());
@@ -480,7 +491,8 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testCaseSensitivePaths() throws MalformedURLException {
-        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Allow: /AnyPage.html" + CRLF + "Allow: /somepage.html" + CRLF + "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Allow: /AnyPage.html" + CRLF + "Allow: /somepage.html"
+                + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
         assertTrue(rules.isAllowed("http://www.domain.com/AnyPage.html"));
@@ -508,7 +520,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testMultiWildcard() throws MalformedURLException {
         // Make sure we only take the first wildcard entry.
-        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: *" + CRLF + "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF
+                + CRLF + "User-agent: *" + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
@@ -518,7 +531,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testMultiMatches() throws MalformedURLException {
         // Make sure we only take the first record that matches.
-        final String simpleRobotsTxt = "User-agent: crawlerbot" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: crawler" + CRLF + "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: crawlerbot" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /"
+                + CRLF + CRLF + "User-agent: crawler" + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("crawlerbot", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
@@ -528,7 +542,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testMultiAgentNames() throws MalformedURLException {
         // When there are more than one agent name on a line.
-        final String simpleRobotsTxt = "User-agent: crawler1 crawler2" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /";
+        final String simpleRobotsTxt = "User-agent: crawler1 crawler2" + CRLF + "Disallow: /index.html" + CRLF
+                + "Allow: /";
 
         BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
@@ -538,7 +553,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testMultiWordAgentName() throws MalformedURLException {
         // When the user agent name has a space in it.
-        final String simpleRobotsTxt = "User-agent: Download Ninja" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /";
+        final String simpleRobotsTxt = "User-agent: Download Ninja" + CRLF + "Disallow: /index.html" + CRLF
+                + "Allow: /";
 
         BaseRobotRules rules = createRobotRules("Download Ninja", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
@@ -548,7 +564,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testUnsupportedFields() throws MalformedURLException {
         // When we have a new field type that we don't know about.
-        final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + "newfield: 234" + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /"
+                + CRLF + "newfield: 234" + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.domain.com/anypage.html"));
@@ -598,13 +615,15 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testCrawlDelay() {
-        final String delayRules1RobotsTxt = "User-agent: bixo" + CR + "Crawl-delay: 10" + CR + "User-agent: foobot" + CR + "Crawl-delay: 20" + CR + "User-agent: *" + CR + "Disallow:/baz" + CR;
+        final String delayRules1RobotsTxt = "User-agent: bixo" + CR + "Crawl-delay: 10" + CR + "User-agent: foobot" + CR
+                + "Crawl-delay: 20" + CR + "User-agent: *" + CR + "Disallow:/baz" + CR;
 
         BaseRobotRules rules = createRobotRules("bixo", delayRules1RobotsTxt.getBytes());
         long crawlDelay = rules.getCrawlDelay();
         assertEquals("testing crawl delay for agent bixo - rule 1", 10000, crawlDelay);
 
-        final String delayRules2RobotsTxt = "User-agent: foobot" + CR + "Crawl-delay: 20" + CR + "User-agent: *" + CR + "Disallow:/baz" + CR;
+        final String delayRules2RobotsTxt = "User-agent: foobot" + CR + "Crawl-delay: 20" + CR + "User-agent: *" + CR
+                + "Disallow:/baz" + CR;
 
         rules = createRobotRules("bixo", delayRules2RobotsTxt.getBytes());
         crawlDelay = rules.getCrawlDelay();
@@ -621,8 +640,10 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testBrokenKrugleRobotsTxtFile() throws MalformedURLException {
-        final String krugleRobotsTxt = "User-agent: *" + CR + "Disallow: /maintenance.html" + CR + "Disallow: /perl/" + CR + "Disallow: /cgi-bin/" + CR + "Disallow: /examples/" + CR
-                        + "Crawl-delay: 3" + CR + "" + CR + "User-agent: googlebot" + CR + "Crawl-delay: 1" + CR + "" + CR + "User-agent: qihoobot" + CR + "Disallow: /";
+        final String krugleRobotsTxt = "User-agent: *" + CR + "Disallow: /maintenance.html" + CR + "Disallow: /perl/"
+                + CR + "Disallow: /cgi-bin/" + CR + "Disallow: /examples/" + CR + "Crawl-delay: 3" + CR + "" + CR
+                + "User-agent: googlebot" + CR + "Crawl-delay: 1" + CR + "" + CR + "User-agent: qihoobot" + CR
+                + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt.getBytes());
         assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
@@ -693,7 +714,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testExtendedStandard() throws Exception {
         SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
-        robotParser.parseContent(FAKE_ROBOTS_URL, readFile("/robots/extended-standard-robots.txt"), "text/plain", "foobot");
+        robotParser.parseContent(FAKE_ROBOTS_URL, readFile("/robots/extended-standard-robots.txt"), "text/plain",
+                "foobot");
         assertEquals("Zero warnings with expended directives", 0, robotParser.getNumWarnings());
     }
 
@@ -726,7 +748,8 @@ public class SimpleRobotRulesParserTest {
     @Test
     public void testMalformedPathInRobotsFile() throws Exception {
         BaseRobotRules rules = createRobotRules("bot1", readFile("/robots/malformed-path.txt"));
-        assertFalse("Disallowed URL", rules.isAllowed("http://en.wikipedia.org/wiki/Wikipedia_talk:Mediation_Committee/"));
+        assertFalse("Disallowed URL",
+                rules.isAllowed("http://en.wikipedia.org/wiki/Wikipedia_talk:Mediation_Committee/"));
         assertTrue("Regular URL", rules.isAllowed("http://en.wikipedia.org/wiki/"));
     }
 
@@ -756,7 +779,8 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     public void testSpacesInMultipleUserAgentNames() throws Exception {
-        final String simpleRobotsTxt = "User-agent: One, Two, Three" + CRLF + "Disallow: /" + CRLF + "" + CRLF + "User-agent: *" + CRLF + "Allow: /" + CRLF;
+        final String simpleRobotsTxt = "User-agent: One, Two, Three" + CRLF + "Disallow: /" + CRLF + "" + CRLF
+                + "User-agent: *" + CRLF + "Allow: /" + CRLF;
 
         BaseRobotRules rules = createRobotRules("One", simpleRobotsTxt.getBytes());
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
@@ -769,6 +793,16 @@ public class SimpleRobotRulesParserTest {
 
         rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
         assertTrue(rules.isAllowed("http://www.fict.com/fish"));
+    }
+
+    @Test
+    public void testTwoTimesUserAgent() throws Exception {
+        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /dataset/rate/" + CRLF + CRLF
+                + "User-Agent: *" + CRLF + "Crawl-Delay: 10";
+
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes());
+
+        assertEquals(10000, rules.getCrawlDelay());
     }
 
     private byte[] readFile(String filename) throws Exception {


### PR DESCRIPTION
Hi all,

first of all, thanks for sharing this project! :)

### Improvement

I encountered a problem with the parsing of `robots.txt` files. I saw examples in which a user-agent has been defined more than ones. An example for this is http://datahub.io/robots.txt containing `User-agent: *` and `User-Agent: *` in a second paragraph. From my point of view this is not really nice, but it does not seem to be prohibited.

### Problem

I adapted the code of the SimpleRobotRulesParser class. Unfortunately, one of the test cases is not green any more. From my point of view, this could be a problem of the test case. Thus, before merging this pull request we might discuss the `testNutchCases` method of the JUnit test.

The robot.txt file of the test case looks like this:
```
User-Agent: Agent1 #foo  
Disallow: /a  
Disallow: /b/a
#Disallow: /c  

User-Agent: Agent2 Agent3#foo  
User-Agent: Agent4
Disallow: /d  
Disallow: /e/d/  

User-Agent: *
Disallow: /foo/bar/
```
This file is stored in the `content` variable and parsed as follows:
```
SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
return robotParser.parseContent("http://domain.com", content, "text/plain", "Agent5,Agent2,Agent1,Agent3,*");
```
The parser should look for rules for the agents `Agent5,Agent2,Agent1,Agent3` and `*`. After that the different pages of the domain are tested leading to an `AssertionError` for the following lines:
```
assertTrue(rules.isAllowed("http://www.domain.com/d"));
assertTrue(rules.isAllowed("http://www.domain.com/d/a"));
assertTrue(rules.isAllowed("http://www.domain.com/e/d/foo.html"));
assertTrue(rules.isAllowed("http://www.domain.com/foo/bar/baz.html"));
```
But from my point of view those pages are prohibited for the given agent names. The first three pages because of `Agent2` and `Agent3` and the last one because of `*`.

What do you think?

### Disadvantage

The changes I made to the parse class have a small disadvantage. (If I understood it correctly) the old implementation searched for a user-agent line, that matched the name of the agent. If such a user-agent has been found and all rule lines for this agent have been parsed, the parser was exiting the parsing routine if it found an additional user-agent with a different name than the agent name. This was simply caused by the idea, that for every user agent only one set of rules would be defined. Since I experienced the opposite, I had to delete this mechanism, forcing the parser to always parse the whole file.

Cheers,
Michael