### PR TITLE
Upgrades httpclient to version 4.5.1 and fixes deprecated methods

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.7-SNAPSHOT (yyyy-mm-dd)
+- Issue 84: Upgraded http-client to version 4.5.1 (aecio)
 - Issue 89: Upgraded Tika 1.10 (jnioche)
 - Issue 82: [Sitemaps] Upgrade Valid / Legal / Strict SitemapUrls (Avi Hayun)
 - Issue 60: [Sitemaps] Upgrade Valid / Legal / Strict SitemapUrls (Avi Hayun)

--- a/pom.xml
+++ b/pom.xml
@@ -198,7 +198,7 @@
 					</systemPropertyVariables>
 					<argLine>-Xmx512m</argLine>
 					<forkMode>always</forkMode>
-					<testFailureIgnore>true</testFailureIgnore>
+					<testFailureIgnore>false</testFailureIgnore>
 				</configuration>
 			</plugin>
 			<plugin>
@@ -327,7 +327,7 @@
 	<properties>
 		<!-- Dependencies -->
 
-		<httpclient.version>4.3.5</httpclient.version>
+		<httpclient.version>4.5.1</httpclient.version>
 		<commons-io.version>2.4</commons-io.version>
 		<tika-core.version>1.10</tika-core.version>
 		<slf4j-api.version>1.7.7</slf4j-api.version>


### PR DESCRIPTION
This pull request upgrades httpclient library to version 4.5.1 and removes all deprecated methods usages from SimpleHttpFetcher. This class is in process of being deprecated, but this can still be useful and it would be good to have this in the next version.