### PR TITLE
Added URLFilter interface + BasicURLNormalizer borrowed from Nutch

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.7-SNAPSHOT (yyyy-mm-dd)
+- Issue 106: Added URLFilter interface + BasicURLNormalizer (jnioche)
 - Issue 89: Upgraded Tika 1.10 (jnioche)
 - Issue 82: [Sitemaps] Upgrade Valid / Legal / Strict SitemapUrls (Avi Hayun)
 - Issue 60: [Sitemaps] Upgrade Valid / Legal / Strict SitemapUrls (Avi Hayun)

--- a/src/main/java/crawlercommons/filters/URLFilter.java
+++ b/src/main/java/crawlercommons/filters/URLFilter.java
@@ -1,11 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package crawlercommons.filters;
 
-public interface URLFilter {
+public abstract class URLFilter {
 
     /**
      * Returns a modified version of the input URL or null if the URL should be
      * removed
      **/
-    public String filter(String urlString);
+    public abstract String filter(String urlString);
 
 }

--- a/src/main/java/crawlercommons/filters/URLFilter.java
+++ b/src/main/java/crawlercommons/filters/URLFilter.java
@@ -6,6 +6,6 @@ public interface URLFilter {
      * Returns a modified version of the input URL or null if the URL should be
      * removed
      **/
-    public String normalize(String urlString);
+    public String filter(String urlString);
 
 }

--- a/src/main/java/crawlercommons/filters/URLFilter.java
+++ b/src/main/java/crawlercommons/filters/URLFilter.java
@@ -1,0 +1,11 @@
+package crawlercommons.filters;
+
+public interface URLFilter {
+
+    /**
+     * Returns a modified version of the input URL or null if the URL should be
+     * removed
+     **/
+    public String normalize(String urlString);
+
+}

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -82,7 +82,7 @@ public class BasicURLNormalizer implements URLFilter {
     }
 
     @Override
-    public String normalize(String urlString) {
+    public String filter(String urlString) {
 
         if ("".equals(urlString)) // permit empty
             return urlString;
@@ -281,7 +281,7 @@ public class BasicURLNormalizer implements URLFilter {
         String line, normUrl;
         BufferedReader in = new BufferedReader(new InputStreamReader(System.in, utf8));
         while ((line = in.readLine()) != null) {
-            normUrl = normalizer.normalize(line);
+            normUrl = normalizer.filter(line);
             LOG.info("{} => {}", line, normUrl);
         }
         System.exit(0);

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -1,0 +1,290 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.filters.basic;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.Locale;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import crawlercommons.filters.URLFilter;
+
+/**
+ * Code borrowed from Apache Nutch. Converts URLs to a normal form:
+ * <ul>
+ * <li>remove dot segments in path: <code>/./</code> or <code>/../</code></li>
+ * <li>remove default ports, e.g. 80 for protocol <code>http://</code></li>
+ * <li>normalize <a href=
+ * "https://en.wikipedia.org/wiki/Percent-encoding#Percent-encoding_in_a_URI">
+ * percent-encoding</a> in URL paths</li>
+ * </ul>
+ */
+public class BasicURLNormalizer implements URLFilter {
+    public static final Logger LOG = LoggerFactory.getLogger(BasicURLNormalizer.class);
+
+    /**
+     * Pattern to detect whether a URL path could be normalized. Contains one of
+     * /. or ./ /.. or ../ //
+     */
+    private final static Pattern hasNormalizablePathPattern = Pattern.compile("/[./]|[.]/");
+
+    /**
+     * Nutch 1098 - finds URL encoded parts of the URL
+     */
+    private final static Pattern unescapeRulePattern = Pattern.compile("%([0-9A-Fa-f]{2})");
+
+    // charset used for encoding URLs before escaping
+    private final static Charset utf8 = Charset.forName("UTF-8");
+
+    /** look-up table for characters which should not be escaped in URL paths */
+    private final static boolean[] unescapedCharacters = new boolean[128];
+
+    static {
+        for (int c = 0; c < 128; c++) {
+            /*
+             * https://tools.ietf.org/html/rfc3986#section-2.2 For consistency,
+             * percent-encoded octets in the ranges of ALPHA (%41-%5A and
+             * %61-%7A), DIGIT (%30-%39), hyphen (%2D), period (%2E), underscore
+             * (%5F), or tilde (%7E) should not be created by URI producers and,
+             * when found in a URI, should be decoded to their corresponding
+             * unreserved characters by URI normalizers.
+             */
+            if ((0x41 <= c && c <= 0x5A) || (0x61 <= c && c <= 0x7A) || (0x30 <= c && c <= 0x39) || c == 0x2D || c == 0x2E || c == 0x5F || c == 0x7E) {
+                unescapedCharacters[c] = true;
+            } else {
+                unescapedCharacters[c] = false;
+            }
+        }
+    }
+
+    @Override
+    public String normalize(String urlString) {
+
+        if ("".equals(urlString)) // permit empty
+            return urlString;
+
+        urlString = urlString.trim(); // remove extra spaces
+
+        URL url = null;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            LOG.info("Malformed URL {}", urlString);
+            return null;
+        }
+
+        String protocol = url.getProtocol();
+        String host = url.getHost();
+        int port = url.getPort();
+        String file = url.getFile();
+
+        boolean changed = false;
+
+        if (!urlString.startsWith(protocol)) // protocol was lowercased
+            changed = true;
+
+        if ("http".equals(protocol) || "https".equals(protocol) || "ftp".equals(protocol)) {
+
+            if (host != null) {
+                String newHost = host.toLowerCase(Locale.ROOT); // lowercase
+                                                                // host
+                if (!host.equals(newHost)) {
+                    host = newHost;
+                    changed = true;
+                }
+            }
+
+            if (port == url.getDefaultPort()) { // uses default port
+                port = -1; // so don't specify it
+                changed = true;
+            }
+
+            if (file == null || "".equals(file)) { // add a slash
+                file = "/";
+                changed = true;
+            }
+
+            if (url.getRef() != null) { // remove the ref
+                changed = true;
+            }
+
+            // check for unnecessary use of "/../", "/./", and "//"
+            String file2 = null;
+            try {
+                file2 = getFileWithNormalizedPath(url);
+            } catch (MalformedURLException e) {
+                LOG.info("Malformed URL {}", url);
+                return null;
+            }
+            if (!file.equals(file2)) {
+                changed = true;
+                file = file2;
+            }
+        }
+
+        // properly encode characters in path/file using percent-encoding
+        String file2 = unescapePath(file);
+        file2 = escapePath(file2);
+        if (!file.equals(file2)) {
+            changed = true;
+            file = file2;
+        }
+
+        if (changed)
+            try {
+                urlString = new URL(protocol, host, port, file).toString();
+            } catch (MalformedURLException e) {
+                LOG.info("Malformed URL {}{}{}{}", protocol, host, port, file);
+                return null;
+            }
+
+        return urlString;
+    }
+
+    private String getFileWithNormalizedPath(URL url) throws MalformedURLException {
+        String file;
+
+        if (hasNormalizablePathPattern.matcher(url.getPath()).find()) {
+            // only normalize the path if there is something to normalize
+            // to avoid needless work
+            try {
+                file = url.toURI().normalize().toURL().getFile();
+                // URI.normalize() does not normalize leading dot segments,
+                // see also http://tools.ietf.org/html/rfc3986#section-5.2.4
+                int start = 0;
+                while (file.startsWith("/../", start)) {
+                    start += 3;
+                }
+                if (start > 0) {
+                    file = file.substring(start);
+                }
+            } catch (URISyntaxException e) {
+                file = url.getFile();
+            }
+        } else {
+            file = url.getFile();
+        }
+
+        // if path is empty return a single slash
+        if (file.isEmpty()) {
+            file = "/";
+        }
+
+        return file;
+    }
+
+    /**
+     * Remove % encoding from path segment in URL for characters which should be
+     * unescaped according to <a
+     * href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC3986</a>.
+     */
+    private String unescapePath(String path) {
+        StringBuilder sb = new StringBuilder();
+
+        Matcher matcher = unescapeRulePattern.matcher(path);
+
+        int end = -1;
+        int letter;
+
+        // Traverse over all encoded groups
+        while (matcher.find()) {
+            // Append everything up to this group
+            sb.append(path.substring(end + 1, matcher.start()));
+
+            // Get the integer representation of this hexadecimal encoded
+            // character
+            letter = Integer.valueOf(matcher.group().substring(1), 16);
+
+            if (letter < 128 && unescapedCharacters[letter]) {
+                // character should be unescaped in URLs
+                sb.append(new Character((char) letter));
+            } else {
+                // Append the encoded character as uppercase
+                sb.append(matcher.group().toUpperCase(Locale.ROOT));
+            }
+
+            end = matcher.start() + 2;
+        }
+
+        letter = path.length();
+
+        // Append the rest if there's anything
+        if (end <= letter - 1) {
+            sb.append(path.substring(end + 1, letter));
+        }
+
+        // Ok!
+        return sb.toString();
+    }
+
+    /**
+     * Convert path segment of URL from Unicode to UTF-8 and escape all
+     * characters which should be escaped according to <a
+     * href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC3986</a>..
+     */
+    private String escapePath(String path) {
+        StringBuilder sb = new StringBuilder(path.length());
+
+        // Traverse over all bytes in this URL
+        for (byte b : path.getBytes(utf8)) {
+            // Is this a control character?
+            if (b < 33 || b == 91 || b == 93) {
+                // Start escape sequence
+                sb.append('%');
+
+                // Get this byte's hexadecimal representation
+                String hex = Integer.toHexString(b & 0xFF).toUpperCase(Locale.ROOT);
+
+                // Do we need to prepend a zero?
+                if (hex.length() % 2 != 0) {
+                    sb.append('0');
+                    sb.append(hex);
+                } else {
+                    // No, append this hexadecimal representation
+                    sb.append(hex);
+                }
+            } else {
+                // No, just append this character as-is
+                sb.append((char) b);
+            }
+        }
+
+        return sb.toString();
+    }
+
+    public static void main(String args[]) throws IOException {
+        BasicURLNormalizer normalizer = new BasicURLNormalizer();
+        String line, normUrl;
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in, utf8));
+        while ((line = in.readLine()) != null) {
+            normUrl = normalizer.normalize(line);
+            LOG.info("{} => {}", line, normUrl);
+        }
+        System.exit(0);
+    }
+
+}

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -43,7 +43,7 @@ import crawlercommons.filters.URLFilter;
  * percent-encoding</a> in URL paths</li>
  * </ul>
  */
-public class BasicURLNormalizer implements URLFilter {
+public class BasicURLNormalizer extends URLFilter {
     public static final Logger LOG = LoggerFactory.getLogger(BasicURLNormalizer.class);
 
     /**

--- a/src/main/java/crawlercommons/filters/package.html
+++ b/src/main/java/crawlercommons/filters/package.html
@@ -1,0 +1,23 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one or more
+contributor license agreements.  See the NOTICE file distributed with
+this work for additional information regarding copyright ownership.
+The ASF licenses this file to You under the Apache License, Version 2.0
+(the "License"); you may not use this file except in compliance with
+the License.  You may obtain a copy of the License at
+  
+     http://www.apache.org/licenses/LICENSE-2.0
+ 
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+<html>
+<body>
+The filters package contains code and resources for URL filtering. This covers both removal and rewriting (e.g. normalisation)
+of URLs. 
+</body>
+<html>
+

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -148,7 +148,7 @@ public class BasicURLNormalizerTest {
     }
 
     private void normalizeTest(String weird, String normal) throws Exception {
-        Assert.assertEquals("normalizing: " + weird, normal, normalizer.normalize(weird));
+        Assert.assertEquals("normalizing: " + weird, normal, normalizer.filter(weird));
     }
 
     public static void main(String[] args) throws Exception {

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.filters.basic;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/** Unit tests for BasicURLNormalizer. */
+public class BasicURLNormalizerTest {
+    private BasicURLNormalizer normalizer;
+
+    public BasicURLNormalizerTest() {
+        normalizer = new BasicURLNormalizer();
+    }
+
+    @Test
+    public void testNUTCH1098() throws Exception {
+        // check that % encoding is normalized
+        normalizeTest("http://foo.com/%66oo.html", "http://foo.com/foo.html");
+
+        // check that % encoding works correctly at end of URL
+        normalizeTest("http://foo.com/%66oo.htm%6c", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/%66oo.ht%6dl", "http://foo.com/foo.html");
+
+        // check that % decoder do not overlap strings
+        normalizeTest("http://foo.com/%66oo.ht%6d%6c", "http://foo.com/foo.html");
+
+        // check that % decoder leaves high bit chars alone
+        normalizeTest("http://foo.com/%66oo.htm%C0", "http://foo.com/foo.htm%C0");
+
+        // check that % decoder leaves control chars alone
+        normalizeTest("http://foo.com/%66oo.htm%1A", "http://foo.com/foo.htm%1A");
+
+        // check that % decoder converts to upper case letters
+        normalizeTest("http://foo.com/%66oo.htm%c0", "http://foo.com/foo.htm%C0");
+
+        // check that % decoder leaves encoded spaces alone
+        normalizeTest("http://foo.com/you%20too.html", "http://foo.com/you%20too.html");
+
+        // check that spaces are encoded into %20
+        normalizeTest("http://foo.com/you too.html", "http://foo.com/you%20too.html");
+
+        // check that encoded # are not decoded
+        normalizeTest("http://foo.com/file.html%23cz", "http://foo.com/file.html%23cz");
+
+        // check that encoded / are not decoded
+        normalizeTest("http://foo.com/fast/dir%2fcz", "http://foo.com/fast/dir%2Fcz");
+
+        // check that control chars are encoded
+        normalizeTest("http://foo.com/\u001a!", "http://foo.com/%1A!");
+
+        // check that control chars are always encoded into 2 digits
+        normalizeTest("http://foo.com/\u0001!", "http://foo.com/%01!");
+
+        // check encoding of spanish chars
+        normalizeTest("http://mydomain.com/en Espa\u00F1ol.aspx", "http://mydomain.com/en%20Espa%C3%B1ol.aspx");
+    }
+
+    @Test
+    public void testNUTCH2064() throws Exception {
+        // Ampersand and colon and other punctuation characters are not to be
+        // unescaped
+        normalizeTest("http://x.com/s?q=a%26b&m=10", "http://x.com/s?q=a%26b&m=10");
+        normalizeTest("http://x.com/show?http%3A%2F%2Fx.com%2Fb", "http://x.com/show?http%3A%2F%2Fx.com%2Fb");
+        normalizeTest("http://google.com/search?q=c%2B%2B", "http://google.com/search?q=c%2B%2B");
+        // do also not touch the query part which is
+        // application/x-www-form-urlencoded
+        normalizeTest("http://x.com/s?q=a+b", "http://x.com/s?q=a+b");
+        // and keep Internationalized domain names
+        // http://bücher.de/ may be http://xn--bcher-kva.de/
+        // but definitely not http://b%C3%BCcher.de/
+        normalizeTest("http://b\u00fccher.de/", "http://b\u00fccher.de/");
+        // test whether percent-encoding works together with other
+        // normalizations
+        normalizeTest("http://x.com/./a/../%66.html", "http://x.com/f.html");
+        // [ and ] need escaping as well
+        normalizeTest("http://x.com/?x[y]=1", "http://x.com/?x%5By%5D=1");
+        // boundary test for first character outside the ASCII range (U+0080)
+        normalizeTest("http://x.com/foo\u0080", "http://x.com/foo%C2%80");
+        normalizeTest("http://x.com/foo%c2%80", "http://x.com/foo%C2%80");
+    }
+
+    @Test
+    public void testNormalizer() throws Exception {
+        // check that leading and trailing spaces are removed
+        normalizeTest(" http://foo.com/ ", "http://foo.com/");
+
+        // check that protocol is lower cased
+        normalizeTest("HTTP://foo.com/", "http://foo.com/");
+
+        // check that host is lower cased
+        normalizeTest("http://Foo.Com/index.html", "http://foo.com/index.html");
+        normalizeTest("http://Foo.Com/index.html", "http://foo.com/index.html");
+
+        // check that port number is normalized
+        normalizeTest("http://foo.com:80/index.html", "http://foo.com/index.html");
+        normalizeTest("http://foo.com:81/", "http://foo.com:81/");
+
+        // check that null path is normalized
+        normalizeTest("http://foo.com", "http://foo.com/");
+
+        // check that references are removed
+        normalizeTest("http://foo.com/foo.html#ref", "http://foo.com/foo.html");
+
+        // // check that encoding is normalized
+        // normalizeTest("http://foo.com/%66oo.html",
+        // "http://foo.com/foo.html");
+
+        // check that unnecessary "../" are removed
+
+        normalizeTest("http://foo.com/aa/./foo.html", "http://foo.com/aa/foo.html");
+        normalizeTest("http://foo.com/aa/../", "http://foo.com/");
+        normalizeTest("http://foo.com/aa/bb/../", "http://foo.com/aa/");
+        normalizeTest("http://foo.com/aa/..", "http://foo.com/");
+        normalizeTest("http://foo.com/aa/bb/cc/../../foo.html", "http://foo.com/aa/foo.html");
+        normalizeTest("http://foo.com/aa/bb/../cc/dd/../ee/foo.html", "http://foo.com/aa/cc/ee/foo.html");
+        normalizeTest("http://foo.com/../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/../../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/../aa/../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/aa/../../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/aa/../bb/../foo.html/../../", "http://foo.com/");
+        normalizeTest("http://foo.com/../aa/foo.html", "http://foo.com/aa/foo.html");
+        normalizeTest("http://foo.com/../aa/../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/a..a/foo.html", "http://foo.com/a..a/foo.html");
+        normalizeTest("http://foo.com/a..a/../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com/foo.foo/../foo.html", "http://foo.com/foo.html");
+        normalizeTest("http://foo.com//aa/bb/foo.html", "http://foo.com/aa/bb/foo.html");
+        normalizeTest("http://foo.com/aa//bb/foo.html", "http://foo.com/aa/bb/foo.html");
+        normalizeTest("http://foo.com/aa/bb//foo.html", "http://foo.com/aa/bb/foo.html");
+        normalizeTest("http://foo.com//aa//bb//foo.html", "http://foo.com/aa/bb/foo.html");
+        normalizeTest("http://foo.com////aa////bb////foo.html", "http://foo.com/aa/bb/foo.html");
+        normalizeTest("http://foo.com/aa?referer=http://bar.com", "http://foo.com/aa?referer=http://bar.com");
+    }
+
+    private void normalizeTest(String weird, String normal) throws Exception {
+        Assert.assertEquals("normalizing: " + weird, normal, normalizer.normalize(weird));
+    }
+
+    public static void main(String[] args) throws Exception {
+        new BasicURLNormalizerTest().testNormalizer();
+    }
+
+}


### PR DESCRIPTION
Related to #74

This PR adds a very simple URLFilter interface with a single method `filter(String URL)` which returns null  if the URL should be filtered out or a modified version of it if it is normalised. This is similar to the approach I used in [storm-crawler](https://github.com/DigitalPebble/storm-crawler/wiki/URLFilters) and is something we meant to do in Nutch a long time ago.

This also contains a modified version of Nutch's BasicURLNormalizer. Later on we could add regex-based URLFilters and normalizers.