### PR TITLE
Fixes bug introduced in pull request #98

### DIFF
--- a/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
+++ b/src/main/java/crawlercommons/fetcher/http/SimpleHttpFetcher.java
@@ -170,6 +170,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
     private HttpVersion _httpVersion;
     private int _socketTimeout;
     private int _connectionTimeout;
+    private int _connectionRequestTimeout;
     private int _maxRetryCount;
 
     transient private CloseableHttpClient _httpClient;
@@ -492,6 +493,18 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
             _connectionTimeout = connectionTimeoutInMs;
         } else {
             throw new IllegalStateException("Can't change connection timeout after HttpClient has been initialized");
+        }
+    }
+
+    public int getConnectionRequestTimeout() {
+        return _connectionRequestTimeout;
+    }
+
+    public void setConnectionRequestTimeout(int _connectionRequestTimeoutInMs) {
+        if (_httpClient == null) {
+            _connectionRequestTimeout = _connectionRequestTimeoutInMs;
+        } else {
+            throw new IllegalStateException("Can't change connection request timeout after HttpClient has been initialized");
         }
     }
 
@@ -901,6 +914,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 // reasonable.
                 requestConfigBuilder.setSocketTimeout(_socketTimeout);
                 requestConfigBuilder.setConnectTimeout(_connectionTimeout);
+                requestConfigBuilder.setConnectionRequestTimeout(_connectionRequestTimeout);
 
                 /*
                  * CoreConnectionPNames.TCP_NODELAY='http.tcp.nodelay':
@@ -1030,6 +1044,7 @@ public class SimpleHttpFetcher extends BaseHttpFetcher {
                 monitor = new IdleConnectionMonitorThread(_connectionManager);
                 monitor.start();
                 
+                httpClientBuilder.setDefaultRequestConfig(requestConfigBuilder.build());
                 _httpClient = httpClientBuilder.build();
             }
         }


### PR DESCRIPTION
Pull request #98 updated httpclient to version 4.5.1. But a small bug was introduced in which the settings being set to the SimpleHttpFetcher were not being used in the final HttpClient object. This PR fixes that problem and also allows the user to configure a new timeout introduced in the new httpclient version.

SimpleHttpFetcher is deprecated, but at least the next version will not introduce this bug if this gets merged.