### PR TITLE
Faster parsing of dates. Fixes #117

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
+++ b/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
@@ -46,9 +46,8 @@ public abstract class AbstractSiteMap {
     };
 
     private static final ThreadLocal<DateFormat> W3C_FULLDATE_FORMAT = new ThreadLocal<DateFormat>() {
-
         protected DateFormat initialValue() {
-            SimpleDateFormat result = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ", Locale.getDefault());
+            SimpleDateFormat result = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.getDefault());
             result.setTimeZone(TimeZone.getTimeZone("UTC"));
             return result;
         }
@@ -149,31 +148,36 @@ public abstract class AbstractSiteMap {
      */
     public static Date convertToDate(String date) {
 
-        if (date != null) {
-            try {
-                return DatatypeConverter.parseDateTime(date).getTime();
-            } catch (IllegalArgumentException e) {
-                // See if it's the one W3C case that the javax.xml.bind
-                // implementation (incorrectly) doesn't handle.
-                Matcher m = W3C_NO_SECONDS_PATTERN.matcher(date);
-                if (m.matches()) {
-                    try {
-                        // Convert to a format that Java can parse, which means
-                        // time zone has to be "-/+HHMM", not "+/-HH:MM"
-                        StringBuffer mungedDate = new StringBuffer(m.group(1));
-                        mungedDate.append(m.group(2));
-                        mungedDate.append(m.group(3));
-                        mungedDate.append(m.group(4));
-                        return W3C_NO_SECONDS_FORMAT.get().parse(mungedDate.toString());
-                    } catch (ParseException e2) {
-                        return null;
-                    }
-                } else {
+        if (date == null) {
+            return null;
+        }
+
+        try {
+            return getFullDateFormat().parse(date);
+        } catch (ParseException e1) {
+        }
+
+        try {
+            return DatatypeConverter.parseDateTime(date).getTime();
+        } catch (IllegalArgumentException e) {
+            // See if it's the one W3C case that the javax.xml.bind
+            // implementation (incorrectly) doesn't handle.
+            Matcher m = W3C_NO_SECONDS_PATTERN.matcher(date);
+            if (m.matches()) {
+                try {
+                    // Convert to a format that Java can parse, which means
+                    // time zone has to be "-/+HHMM", not "+/-HH:MM"
+                    StringBuffer mungedDate = new StringBuffer(m.group(1));
+                    mungedDate.append(m.group(2));
+                    mungedDate.append(m.group(3));
+                    mungedDate.append(m.group(4));
+                    return W3C_NO_SECONDS_FORMAT.get().parse(mungedDate.toString());
+                } catch (ParseException e2) {
                     return null;
                 }
+            } else {
+                return null;
             }
-        } else {
-            return null;
         }
     }
 }


### PR DESCRIPTION
Fixes the format for ISO dates and tries using it before DatatypeConverter. This improves the parsing time by 30 to 40%.

Before (average over 10 iterations in msec)

Average for http://www.foxnews.com/sitemap.xml?idx=26 => 684
Average for http://push.abs-cbn.com/sitemap/2015/ => 238
Average for https://www.novinky.cz/sitemap/sitemap_articles_5.xml => 972

After

Average for http://www.foxnews.com/sitemap.xml?idx=26 => 481
Average for http://push.abs-cbn.com/sitemap/2015/ => 141
Average for https://www.novinky.cz/sitemap/sitemap_articles_5.xml => 657

I also tried java.time (in Java 8) but there was no benefit from it
           ` return Date.from(java.time.ZonedDateTime.parse(date).toInstant());`

Average for http://www.foxnews.com/sitemap.xml?idx=26 => 646
Average for http://push.abs-cbn.com/sitemap/2015/ => 197
Average for https://www.novinky.cz/sitemap/sitemap_articles_5.xml => 1281

