### PR TITLE
BasicURLNormalizer: NPE for URLs without authority

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.8-SNAPSHOT
+- BasicURLNormalizer: NPE for URLs without authority (sebastian-nagel) #136
 - BasicURLNormalizer to strip empty port (sebastian-nagel) #133
 - Remove deprecated HTTP fetcher (kkrugler) #96
 

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -108,7 +108,7 @@ public class BasicURLNormalizer extends URLFilter {
 
         if ("http".equals(protocol) || "https".equals(protocol) || "ftp".equals(protocol)) {
 
-            if (host != null) {
+            if (host != null && url.getAuthority() != null) {
                 String newHost = host.toLowerCase(Locale.ROOT); // lowercase
                                                                 // host
                 if (!host.equals(newHost)) {
@@ -119,6 +119,9 @@ public class BasicURLNormalizer extends URLFilter {
                     // user, etc.) which will likely cause a change if left away
                     changed = true;
                 }
+            } else {
+                // no host or authority: recompose the URL from components
+                changed = true;
             }
 
             if (port == url.getDefaultPort()) { // uses default port

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -147,6 +147,13 @@ public class BasicURLNormalizerTest {
         normalizeTest("http://foo.com//aa//bb//foo.html", "http://foo.com/aa/bb/foo.html");
         normalizeTest("http://foo.com////aa////bb////foo.html", "http://foo.com/aa/bb/foo.html");
         normalizeTest("http://foo.com/aa?referer=http://bar.com", "http://foo.com/aa?referer=http://bar.com");
+
+        // check URLs without host (authority)
+        normalizeTest("file:///foo/bar.txt", "file:///foo/bar.txt");
+        normalizeTest("ftp:/", "ftp:/");
+        normalizeTest("http:", "http:/");
+        normalizeTest("http:////", "http:/");
+        normalizeTest("http:///////", "http:/");
     }
 
     private void normalizeTest(String weird, String normal) throws Exception {


### PR DESCRIPTION
(introduced by #133, cf. [NUTCH-2349](https://issues.apache.org/jira/browse/NUTCH-2349))
- check whether URL.getAuthority() returns null
- recompose URLs without authority with empty authority/host