### PR TITLE
Remove dependencies to system-specific locale, fixes #137

### DIFF
--- a/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
+++ b/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Locale;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,7 +81,8 @@ public class EffectiveTldFinder {
             if (null == effectiveTldDataStream && null != this.getClass().getResource(ETLD_DATA)) {
               effectiveTldDataStream = this.getClass().getResourceAsStream(ETLD_DATA);
             }
-            BufferedReader input = new BufferedReader(new InputStreamReader(effectiveTldDataStream, Charset.defaultCharset()));
+            BufferedReader input = new BufferedReader(new InputStreamReader(
+                    effectiveTldDataStream, StandardCharsets.UTF_8));
             String line = null;
             while (null != (line = input.readLine())) {
                 if (line.length() == 0 || (line.length() > 1 && line.startsWith(COMMENT))) {
@@ -153,8 +155,8 @@ public class EffectiveTldFinder {
      */
     public static String getAssignedDomain(String hostname) {
         EffectiveTLD etld = getEffectiveTLD(hostname);
-        if (null == etld || etld.getDomain() == hostname.toLowerCase(Locale.getDefault())) {
-            return hostname.toLowerCase(Locale.getDefault());
+        if (null == etld || etld.getDomain() == hostname.toLowerCase(Locale.ROOT)) {
+            return hostname.toLowerCase(Locale.ROOT);
         }
         return hostname.replaceFirst(".*?([^.]+\\.)" + etld.getDomain() + "$", "$1" + etld.getDomain());
     }
@@ -205,7 +207,7 @@ public class EffectiveTldFinder {
 
         private String asciiConvert(String str) {
             if (isAscii(str)) {
-                return str.toLowerCase(Locale.getDefault());
+                return str.toLowerCase(Locale.ROOT);
             }
             return IDN.toASCII(str);
         }

--- a/src/main/java/crawlercommons/domains/PaidLevelDomain.java
+++ b/src/main/java/crawlercommons/domains/PaidLevelDomain.java
@@ -76,7 +76,7 @@ public class PaidLevelDomain {
         }
 
         int firstHostPiece = 0;
-        if (ccTLDs.contains(subNames[numPieces - 1].toLowerCase(Locale.getDefault()))) {
+        if (ccTLDs.contains(subNames[numPieces - 1].toLowerCase(Locale.ROOT))) {
             // We have a country code at the end. See if the preceding piece is
             // either
             // a two-letter name (country code or funky short gTLD), or one of
@@ -85,15 +85,15 @@ public class PaidLevelDomain {
             if (subNames[numPieces - 2].length() <= 2) {
                 // Must be xxx.co.jp format
                 firstHostPiece = numPieces - 3;
-            } else if (gTLDs.contains(subNames[numPieces - 2].toLowerCase(Locale.getDefault()))) {
+            } else if (gTLDs.contains(subNames[numPieces - 2].toLowerCase(Locale.ROOT))) {
                 // Must be xxx.com.mx format
                 firstHostPiece = numPieces - 3;
             } else {
                 // Must be xxx.it format
                 firstHostPiece = numPieces - 2;
             }
-        } else if (gTLDs.contains(subNames[numPieces - 1].toLowerCase(Locale.getDefault()))) {
-            if (ccTLDs.contains(subNames[numPieces - 2].toLowerCase(Locale.getDefault()))) {
+        } else if (gTLDs.contains(subNames[numPieces - 1].toLowerCase(Locale.ROOT))) {
+            if (ccTLDs.contains(subNames[numPieces - 2].toLowerCase(Locale.ROOT))) {
                 // Must be xxx.de.com format
                 firstHostPiece = numPieces - 3;
             } else {

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -269,7 +269,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     static {
         for (RobotDirective directive : RobotDirective.values()) {
             if (!directive.isSpecial()) {
-                String prefix = directive.name().toLowerCase(Locale.getDefault()).replaceAll("_", "-");
+                String prefix = directive.name().toLowerCase(Locale.ROOT).replaceAll("_", "-");
                 DIRECTIVE_PREFIX.put(prefix, directive);
             }
         }
@@ -301,7 +301,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * @return robot command found on line
      */
     private static RobotToken tokenize(String line) {
-        String lowerLine = line.toLowerCase(Locale.getDefault());
+        String lowerLine = line.toLowerCase(Locale.ROOT);
         for (String prefix : DIRECTIVE_PREFIX.keySet()) {
             int prefixLength = prefix.length();
             if (lowerLine.startsWith(prefix)) {
@@ -424,7 +424,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
         }
 
         // Decide if we need to do special HTML processing.
-        boolean isHtmlType = ((contentType != null) && contentType.toLowerCase(Locale.getDefault()).startsWith("text/html"));
+        boolean isHtmlType = ((contentType != null) && contentType.toLowerCase(Locale.ROOT).startsWith("text/html"));
 
         // If it looks like it contains HTML, but doesn't have a user agent
         // field, then
@@ -452,7 +452,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
         // tokenizer doesn't return empty tokens, a \r\n sequence still
         // works since it looks like an empty string between the \r and \n.
         StringTokenizer lineParser = new StringTokenizer(contentAsStr, "\n\r\u0085\u2028\u2029");
-        ParseState parseState = new ParseState(url, robotNames.toLowerCase(Locale.getDefault()));
+        ParseState parseState = new ParseState(url, robotNames.toLowerCase(Locale.ROOT));
 
         while (lineParser.hasMoreTokens()) {
             String line = lineParser.nextToken();
@@ -510,7 +510,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                     break;
 
                 case MISSING:
-                reportWarning(String.format(Locale.getDefault(), "Unknown line in robots.txt file (size %d): %s", content.length, line), url);
+                reportWarning(String.format(Locale.ROOT, "Unknown line in robots.txt file (size %d): %s", content.length, line), url);
                 parseState.setFinishedAgentFields(true);
                     break;
 
@@ -575,7 +575,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
 
         // Handle the case when there are multiple target names are passed
         // We assume we should do case-insensitive comparison of target name.
-        String[] targetNames = state.getTargetName().toLowerCase(Locale.getDefault()).split(",");
+        String[] targetNames = state.getTargetName().toLowerCase(Locale.ROOT).split(",");
 
         for (int count = 0; count < targetNames.length; count++) {
             // Extract possible match names from our target agent name, since it
@@ -587,7 +587,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             String[] agentNames = token.getData().split("[ \t,]");
             for (String agentName : agentNames) {
                 // TODO should we do case-insensitive matching? Probably yes.
-                agentName = agentName.trim().toLowerCase(Locale.getDefault());
+                agentName = agentName.trim().toLowerCase(Locale.ROOT);
                 if (agentName.isEmpty()) {
                     // Ignore empty names
                 } else if (agentName.equals("*") && !state.isMatchedWildcard()) {

--- a/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
+++ b/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
@@ -41,13 +41,13 @@ public abstract class AbstractSiteMap {
     private static final ThreadLocal<DateFormat> W3C_NO_SECONDS_FORMAT = new ThreadLocal<DateFormat>() {
 
         protected DateFormat initialValue() {
-            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ", Locale.getDefault());
+            return new SimpleDateFormat("yyyy-MM-dd'T'HH:mmZ", Locale.ROOT);
         }
     };
 
     private static final ThreadLocal<DateFormat> W3C_FULLDATE_FORMAT = new ThreadLocal<DateFormat>() {
         protected DateFormat initialValue() {
-            SimpleDateFormat result = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.getDefault());
+            SimpleDateFormat result = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssX", Locale.ROOT);
             result.setTimeZone(TimeZone.getTimeZone("UTC"));
             return result;
         }

--- a/src/main/java/crawlercommons/sitemaps/SiteMapURL.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapURL.java
@@ -236,7 +236,7 @@ public class SiteMapURL {
     public void setChangeFrequency(String changeFreq) {
 
         if (changeFreq != null) {
-            changeFreq = changeFreq.toUpperCase(Locale.getDefault());
+            changeFreq = changeFreq.toUpperCase(Locale.ROOT);
 
             if (changeFreq.contains("ALWAYS")) {
                 this.changeFreq = ChangeFrequency.ALWAYS;

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -706,7 +706,7 @@ public class SimpleRobotRulesParserTest {
         assertEquals("Found sitemap", 3, rules.getSitemaps().size());
         // check that the last one is not lowercase only
         String url = rules.getSitemaps().get(2);
-        boolean lowercased = url.equals(url.toLowerCase(Locale.getDefault()));
+        boolean lowercased = url.equals(url.toLowerCase(Locale.ROOT));
         assertFalse("Sitemap case check", lowercased);
     }
 

--- a/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
+++ b/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
@@ -31,7 +31,7 @@ public class AbstractSiteMapTest {
         assertNull(AbstractSiteMap.convertToDate("blah"));
         assertNull(AbstractSiteMap.convertToDate(null));
 
-        SimpleDateFormat isoFormatNoTimezone = new SimpleDateFormat("yyyyMMdd", Locale.getDefault());
+        SimpleDateFormat isoFormatNoTimezone = new SimpleDateFormat("yyyyMMdd", Locale.ROOT);
 
         // For formats where there's no time zone information, the time zone is
         // undefined, so we can
@@ -40,7 +40,7 @@ public class AbstractSiteMapTest {
         assertEquals("20140601", isoFormatNoTimezone.format(AbstractSiteMap.convertToDate("2014-06")));
         assertEquals("20140603", isoFormatNoTimezone.format(AbstractSiteMap.convertToDate("2014-06-03")));
 
-        SimpleDateFormat isoFormat = new SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.getDefault());
+        SimpleDateFormat isoFormat = new SimpleDateFormat("yyyyMMdd'T'HHmmss", Locale.ROOT);
         isoFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
 
         // Complete date plus hours and minutes
@@ -55,7 +55,7 @@ public class AbstractSiteMapTest {
 
         // Complete date plus hours, minutes, seconds and a decimal fraction of
         // a second
-        SimpleDateFormat isoFormatWithFractionSeconds = new SimpleDateFormat("yyyyMMdd'T'HHmmss.S", Locale.getDefault());
+        SimpleDateFormat isoFormatWithFractionSeconds = new SimpleDateFormat("yyyyMMdd'T'HHmmss.S", Locale.ROOT);
         isoFormatWithFractionSeconds.setTimeZone(TimeZone.getTimeZone("UTC"));
         assertEquals("20140603T103045.820", isoFormatWithFractionSeconds.format(AbstractSiteMap.convertToDate("2014-06-03T10:30:45.82+00:00")));
 

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -83,7 +84,7 @@ public class SiteMapParserTest {
 
     @Test
     public void testFullDateFormat() {
-        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm+hh:00", Locale.getDefault());
+        SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm+hh:00", Locale.ROOT);
         Date date = new Date();
         LOG.info(format.format(date));
         LOG.info(SiteMap.getFullDateFormat().format(date));


### PR DESCRIPTION
- use Locale.ROOT instead of Locale.getDefault()
- set encoding for resources to UTF-8
  (StandardCharsets.UTF_8 instead of Charset.defaultCharset())

Verified fix (mvn verify) with the following locales: C, tr_TR, tr_TR.utf8, fa_IR, fa_IR.utf8