### PR TITLE
Use constants from StandardCharsets where applicable, fixes #141

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.8-SNAPSHOT
+- Use StandardCharsets where applicable (sebastian-nagel) #141
 - Increase sitemap size limit to 50MB (Chaiavi) #132
 - Remove dependencies to system-specific locale (sebastian-nagel) #137
 - BasicURLNormalizer: NPE for URLs without authority (sebastian-nagel) #136

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -16,13 +16,14 @@
 
 package crawlercommons.filters.basic;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -55,9 +56,6 @@ public class BasicURLNormalizer extends URLFilter {
      * Nutch 1098 - finds URL encoded parts of the URL
      */
     private final static Pattern unescapeRulePattern = Pattern.compile("%([0-9A-Fa-f]{2})");
-
-    // charset used for encoding URLs before escaping
-    private final static Charset utf8 = Charset.forName("UTF-8");
 
     /** look-up table for characters which should not be escaped in URL paths */
     private final static boolean[] unescapedCharacters = new boolean[128];
@@ -256,7 +254,7 @@ public class BasicURLNormalizer extends URLFilter {
         StringBuilder sb = new StringBuilder(path.length());
 
         // Traverse over all bytes in this URL
-        for (byte b : path.getBytes(utf8)) {
+        for (byte b : path.getBytes(UTF_8)) {
             // Is this a control character?
             if (b < 33 || b == 91 || b == 93) {
                 // Start escape sequence
@@ -285,7 +283,7 @@ public class BasicURLNormalizer extends URLFilter {
     public static void main(String args[]) throws IOException {
         BasicURLNormalizer normalizer = new BasicURLNormalizer();
         String line, normUrl;
-        BufferedReader in = new BufferedReader(new InputStreamReader(System.in, utf8));
+        BufferedReader in = new BufferedReader(new InputStreamReader(System.in, UTF_8));
         while ((line = in.readLine()) != null) {
             normUrl = normalizer.filter(line);
             LOG.info("{} => {}", line, normUrl);

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -16,9 +16,10 @@
 
 package crawlercommons.robots;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -395,33 +396,29 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
 
         int bytesLen = content.length;
         int offset = 0;
-        String encoding = "us-ascii";
+        Charset encoding = StandardCharsets.US_ASCII;
 
         // Check for a UTF-8 BOM at the beginning (EF BB BF)
         if ((bytesLen >= 3) && (content[0] == (byte) 0xEF) && (content[1] == (byte) 0xBB) && (content[2] == (byte) 0xBF)) {
             offset = 3;
             bytesLen -= 3;
-            encoding = "UTF-8";
+            encoding = StandardCharsets.UTF_8;
         }
         // Check for UTF-16LE BOM at the beginning (FF FE)
         else if ((bytesLen >= 2) && (content[0] == (byte) 0xFF) && (content[1] == (byte) 0xFE)) {
             offset = 2;
             bytesLen -= 2;
-            encoding = "UTF-16LE";
+            encoding = StandardCharsets.UTF_16LE;
         }
         // Check for UTF-16BE BOM at the beginning (FE FF)
         else if ((bytesLen >= 2) && (content[0] == (byte) 0xFE) && (content[1] == (byte) 0xFF)) {
             offset = 2;
             bytesLen -= 2;
-            encoding = "UTF-16BE";
+            encoding = StandardCharsets.UTF_16BE;
         }
 
         String contentAsStr;
-        try {
-            contentAsStr = new String(content, offset, bytesLen, encoding);
-        } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException("Impossible unsupported encoding exception for " + encoding);
-        }
+        contentAsStr = new String(content, offset, bytesLen, encoding);
 
         // Decide if we need to do special HTML processing.
         boolean isHtmlType = ((contentType != null) && contentType.toLowerCase(Locale.ROOT).startsWith("text/html"));

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -16,12 +16,13 @@
 
 package crawlercommons.sitemaps;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.io.UnsupportedEncodingException;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
@@ -214,12 +215,7 @@ public class SiteMapParser {
 
         BOMInputStream bomIs = new BOMInputStream(new ByteArrayInputStream(xmlContent));
         InputSource is = new InputSource();
-        try {
-            is.setCharacterStream(new BufferedReader(new InputStreamReader(bomIs, "UTF-8")));
-        } catch (UnsupportedEncodingException e) {
-            IOUtils.closeQuietly(bomIs);
-            throw new RuntimeException("Impossible exception", e);
-        }
+        is.setCharacterStream(new BufferedReader(new InputStreamReader(bomIs, UTF_8)));
 
         return processXml(sitemapUrl, is);
     }
@@ -241,7 +237,7 @@ public class SiteMapParser {
 
         BOMInputStream bomIs = new BOMInputStream(new ByteArrayInputStream(content));
         @SuppressWarnings("resource")
-        BufferedReader reader = new BufferedReader(new InputStreamReader(bomIs, "UTF-8"));
+        BufferedReader reader = new BufferedReader(new InputStreamReader(bomIs, UTF_8));
 
         String line;
         int i = 1;

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -16,14 +16,14 @@
 
 package crawlercommons.robots;
 
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
 import java.util.Arrays;
 import java.util.Locale;
 
@@ -45,26 +45,26 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testEmptyRules() throws MalformedURLException, UnsupportedEncodingException {
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", "".getBytes("UTF-8"));
+    public void testEmptyRules() {
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", "".getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testQueryParamInDisallow() throws Exception {
+    public void testQueryParamInDisallow() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.cfm?fuseaction=sitesearch.results*";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://searchservice.domain.com/index.cfm?fuseaction=sitesearch.results&type=People&qry=california&pg=2"));
     }
 
     @Test
-    public void testGooglePatternMatching() throws Exception {
+    public void testGooglePatternMatching() {
 
         // Test for /fish
         final String simpleRobotsTxt1 = "User-agent: *" + CRLF + "Disallow: /fish" + CRLF;
 
-        BaseRobotRules rule1 = createRobotRules("Any-darn-crawler", simpleRobotsTxt1.getBytes("UTF-8"));
+        BaseRobotRules rule1 = createRobotRules("Any-darn-crawler", simpleRobotsTxt1.getBytes(UTF_8));
         assertFalse(rule1.isAllowed("http://www.fict.com/fish"));
         assertFalse(rule1.isAllowed("http://www.fict.com/fish.html"));
         assertFalse(rule1.isAllowed("http://www.fict.com/fish/salmon.html"));
@@ -80,7 +80,7 @@ public class SimpleRobotRulesParserTest {
         // Test for /fish*
         final String simpleRobotsTxt2 = "User-agent: *" + CRLF + "Disallow: /fish*" + CRLF;
 
-        BaseRobotRules rule2 = createRobotRules("Any-darn-crawler", simpleRobotsTxt2.getBytes("UTF-8"));
+        BaseRobotRules rule2 = createRobotRules("Any-darn-crawler", simpleRobotsTxt2.getBytes(UTF_8));
         assertFalse(rule2.isAllowed("http://www.fict.com/fish"));
         assertFalse(rule2.isAllowed("http://www.fict.com/fish.html"));
         assertFalse(rule2.isAllowed("http://www.fict.com/fish/salmon.html"));
@@ -96,7 +96,7 @@ public class SimpleRobotRulesParserTest {
         // Test for /fish/
         final String simpleRobotsTxt3 = "User-agent: *" + CRLF + "Disallow: /fish/" + CRLF;
 
-        BaseRobotRules rule3 = createRobotRules("Any-darn-crawler", simpleRobotsTxt3.getBytes("UTF-8"));
+        BaseRobotRules rule3 = createRobotRules("Any-darn-crawler", simpleRobotsTxt3.getBytes(UTF_8));
         assertFalse(rule3.isAllowed("http://www.fict.com/fish/"));
         assertFalse(rule3.isAllowed("http://www.fict.com/fish/?id=anything"));
         assertFalse(rule3.isAllowed("http://www.fict.com/fish/salmon.htm"));
@@ -108,7 +108,7 @@ public class SimpleRobotRulesParserTest {
         // Test for /*.php
         final String simpleRobotsTxt4 = "User-agent: *" + CRLF + "Disallow: /*.php" + CRLF;
 
-        BaseRobotRules rule4 = createRobotRules("Any-darn-crawler", simpleRobotsTxt4.getBytes("UTF-8"));
+        BaseRobotRules rule4 = createRobotRules("Any-darn-crawler", simpleRobotsTxt4.getBytes(UTF_8));
         assertFalse(rule4.isAllowed("http://www.fict.com/filename.php"));
         assertFalse(rule4.isAllowed("http://www.fict.com/folder/filename.php"));
         assertFalse(rule4.isAllowed("http://www.fict.com/folder/filename.php?parameters"));
@@ -121,7 +121,7 @@ public class SimpleRobotRulesParserTest {
         // Test for /*.php$
         final String simpleRobotsTxt5 = "User-agent: *" + CRLF + "Disallow: /*.php$" + CRLF;
 
-        BaseRobotRules rule5 = createRobotRules("Any-darn-crawler", simpleRobotsTxt5.getBytes("UTF-8"));
+        BaseRobotRules rule5 = createRobotRules("Any-darn-crawler", simpleRobotsTxt5.getBytes(UTF_8));
         assertFalse(rule5.isAllowed("http://www.fict.com/filename.php"));
         assertFalse(rule5.isAllowed("http://www.fict.com/folder/filename.php"));
 
@@ -133,7 +133,7 @@ public class SimpleRobotRulesParserTest {
         // Test for /fish*.php
         final String simpleRobotsTxt6 = "User-agent: *" + CRLF + "Disallow: /fish*.php" + CRLF;
 
-        BaseRobotRules rule6 = createRobotRules("Any-darn-crawler", simpleRobotsTxt6.getBytes("UTF-8"));
+        BaseRobotRules rule6 = createRobotRules("Any-darn-crawler", simpleRobotsTxt6.getBytes(UTF_8));
         assertFalse(rule6.isAllowed("http://www.fict.com/fish.php"));
         assertFalse(rule6.isAllowed("http://www.fict.com/fishheads/catfish.php?parameters"));
 
@@ -142,68 +142,68 @@ public class SimpleRobotRulesParserTest {
         // Test rule with multiple '*' characters
         final String simpleRobotsTxt7 = "User-agent: *" + CRLF + "Disallow: /*fish*.php" + CRLF;
 
-        BaseRobotRules rule7 = createRobotRules("Any-darn-crawler", simpleRobotsTxt7.getBytes("UTF-8"));
+        BaseRobotRules rule7 = createRobotRules("Any-darn-crawler", simpleRobotsTxt7.getBytes(UTF_8));
         assertFalse(rule7.isAllowed("http://www.fict.com/fish.php"));
         assertFalse(rule7.isAllowed("http://www.fict.com/superfishheads/catfish.php?parameters"));
         assertTrue(rule7.isAllowed("http://www.fict.com/fishheads/catfish.htm"));
     }
 
     @Test
-    public void testCommentedOutLines() throws MalformedURLException, UnsupportedEncodingException {
+    public void testCommentedOutLines() {
         final String simpleRobotsTxt = "#user-agent: testAgent" + LF + LF + "#allow: /index.html" + LF + "#allow: /test" + LF + LF + "#user-agent: test" + LF + LF + "#allow: /index.html" + LF
                         + "#disallow: /test" + LF + LF + "#user-agent: someAgent" + LF + LF + "#disallow: /index.html" + LF + "#disallow: /test" + LF + LF;
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         Assert.assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testRobotsTxtAlwaysAllowed() throws MalformedURLException, UnsupportedEncodingException {
+    public void testRobotsTxtAlwaysAllowed() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/robots.txt"));
     }
 
     @Test
-    public void testAgentNotListed() throws MalformedURLException, UnsupportedEncodingException {
+    public void testAgentNotListed() {
         // Access is assumed to be allowed, if no rules match an agent.
         final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("crawler3", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("crawler3", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/index.html"));
     }
 
     @Test
-    public void testNonAsciiEncoding() throws UnsupportedEncodingException, MalformedURLException {
+    public void testNonAsciiEncoding() {
         final String simpleRobotsTxt = "User-agent: *" + " # \u00A2 \u20B5" + CRLF + "Disallow:";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testSimplestAllowAll() throws MalformedURLException, UnsupportedEncodingException {
+    public void testSimplestAllowAll() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow:";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testMixedEndings() throws MalformedURLException, UnsupportedEncodingException {
+    public void testMixedEndings() {
         final String mixedEndingsRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF + "# comments to webmaster@fict.org" + CR + LF + "User-agent: unhipbot" + LF + "Disallow: /" + CR + ""
                         + CRLF + "User-agent: webcrawler" + LF + "User-agent: excite" + CR + "Disallow: " + "\u0085" + CR + "User-agent: *" + CRLF + "Disallow: /org/plans.html" + LF + "Allow: /org/"
                         + CR + "Allow: /serv" + CRLF + "Allow: /~mak" + LF + "Disallow: /" + CRLF;
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("WebCrawler/3.0", mixedEndingsRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("WebCrawler/3.0", mixedEndingsRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.fict.org/"));
         assertTrue(rules.isAllowed("http://www.fict.org/index.html"));
 
-        rules = createRobotRules("Unknown/1.0", mixedEndingsRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Unknown/1.0", mixedEndingsRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.org/"));
         assertFalse(rules.isAllowed("http://www.fict.org/index.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/robots.txt"));
@@ -219,7 +219,7 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testRfpCases() throws MalformedURLException, UnsupportedEncodingException {
+    public void testRfpCases() {
         // Run through all of the tests that are part of the robots.txt RFP
         // http://www.robotstxt.org/norobots-rfc.txt
         final String rfpExampleRobotsTxt = "# /robots.txt for http://www.fict.org/" + CRLF + "# comments to webmaster@fict.org" + CRLF + CRLF + "User-agent: unhipbot" + CRLF + "Disallow: /" + CRLF
@@ -228,7 +228,7 @@ public class SimpleRobotRulesParserTest {
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("UnhipBot/0.1", rfpExampleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("UnhipBot/0.1", rfpExampleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.org/"));
         assertFalse(rules.isAllowed("http://www.fict.org/index.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/robots.txt"));
@@ -241,7 +241,7 @@ public class SimpleRobotRulesParserTest {
         assertFalse(rules.isAllowed("http://www.fict.org/%7Ejim/jim.html"));
         assertFalse(rules.isAllowed("http://www.fict.org/%7Emak/mak.html"));
 
-        rules = createRobotRules("WebCrawler/3.0", rfpExampleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("WebCrawler/3.0", rfpExampleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.fict.org/"));
         assertTrue(rules.isAllowed("http://www.fict.org/index.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/robots.txt"));
@@ -254,7 +254,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.fict.org/%7Ejim/jim.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/%7Emak/mak.html"));
 
-        rules = createRobotRules("Excite/1.0", rfpExampleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Excite/1.0", rfpExampleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.fict.org/"));
         assertTrue(rules.isAllowed("http://www.fict.org/index.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/robots.txt"));
@@ -267,7 +267,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.fict.org/%7Ejim/jim.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/%7Emak/mak.html"));
 
-        rules = createRobotRules("Unknown/1.0", rfpExampleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Unknown/1.0", rfpExampleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.org/"));
         assertFalse(rules.isAllowed("http://www.fict.org/index.html"));
         assertTrue(rules.isAllowed("http://www.fict.org/robots.txt"));
@@ -282,7 +282,7 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testNutchCases() throws MalformedURLException, UnsupportedEncodingException {
+    public void testNutchCases() {
         // Run through the Nutch test cases.
 
         final String nutchRobotsTxt = "User-Agent: Agent1 #foo" + CR + "Disallow: /a" + CR + "Disallow: /b/a" + CR + "#Disallow: /c" + CR + "" + CR + "" + CR + "User-Agent: Agent2 Agent3#foo" + CR
@@ -290,7 +290,7 @@ public class SimpleRobotRulesParserTest {
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("Agent1", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent1", nutchRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/a"));
         assertFalse(rules.isAllowed("http://www.domain.com/a/"));
         assertFalse(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -312,7 +312,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.domain.com/foo/bar/baz.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/f/"));
 
-        rules = createRobotRules("Agent2", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent2", nutchRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/a"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -334,7 +334,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.domain.com/foo/bar/baz.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/f/"));
 
-        rules = createRobotRules("Agent3", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent3", nutchRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/a"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -356,7 +356,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.domain.com/foo/bar/baz.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/f/"));
 
-        rules = createRobotRules("Agent4", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent4", nutchRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/a"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -378,7 +378,7 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.domain.com/foo/bar/baz.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/f/"));
 
-        rules = createRobotRules("Agent5", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent5", nutchRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/a"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/"));
         assertTrue(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -403,7 +403,7 @@ public class SimpleRobotRulesParserTest {
         // Note that the SimpleRobotRulesParser only parses the rule set of the
         // first matching agent name. For the following example, the parser
         // returns only the rules matching 'Agent1'.
-        rules = createRobotRules("Agent5,Agent2,Agent1,Agent3,*", nutchRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Agent5,Agent2,Agent1,Agent3,*", nutchRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/a"));
         assertFalse(rules.isAllowed("http://www.domain.com/a/"));
         assertFalse(rules.isAllowed("http://www.domain.com/a/bloh/foo.html"));
@@ -427,65 +427,65 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testHtmlMarkupInRobotsTxt() throws MalformedURLException, UnsupportedEncodingException {
+    public void testHtmlMarkupInRobotsTxt() {
         final String htmlRobotsTxt = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 3.2 Final//EN\"><HTML>\n" + "<HEAD>\n" + "<TITLE>/robots.txt</TITLE>\n" + "</HEAD>\n" + "<BODY>\n"
                         + "User-agent: anybot<BR>\n" + "Disallow: <BR>\n" + "Crawl-Delay: 10<BR>\n" + "\n" + "User-agent: *<BR>\n" + "Disallow: /<BR>\n" + "Crawl-Delay: 30<BR>\n" + "\n" + "</BODY>\n"
                         + "</HTML>\n";
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("anybot", htmlRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("anybot", htmlRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/index.html"));
         assertEquals(10000, rules.getCrawlDelay());
 
-        rules = createRobotRules("bogusbot", htmlRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("bogusbot", htmlRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertEquals(30000, rules.getCrawlDelay());
     }
 
     @Test
-    public void testIgnoreOfHtml() throws MalformedURLException, UnsupportedEncodingException {
+    public void testIgnoreOfHtml() {
         final String htmlFile = "<HTML><HEAD><TITLE>Site under Maintenance</TITLE></HTML>";
 
-        BaseRobotRules rules = createRobotRules("anybot", htmlFile.getBytes("us-ascii"));
+        BaseRobotRules rules = createRobotRules("anybot", htmlFile.getBytes(US_ASCII));
         assertTrue(rules.isAllowed("http://www.domain.com/"));
         assertFalse(rules.isDeferVisits());
     }
 
     @Test
-    public void testHeritrixCases() throws MalformedURLException, UnsupportedEncodingException {
+    public void testHeritrixCases() {
         final String heritrixRobotsTxt = "User-agent: *\n" + "Disallow: /cgi-bin/\n" + "Disallow: /details/software\n" + "\n" + "User-agent: denybot\n" + "Disallow: /\n" + "\n"
                         + "User-agent: allowbot1\n" + "Disallow: \n" + "\n" + "User-agent: allowbot2\n" + "Disallow: /foo\n" + "Allow: /\n" + "\n" + "User-agent: delaybot\n" + "Disallow: /\n"
                         + "Crawl-Delay: 20\n" + "Allow: /images/\n";
 
         BaseRobotRules rules;
-        rules = createRobotRules("Mozilla allowbot1 99.9", heritrixRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Mozilla allowbot1 99.9", heritrixRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/path"));
         assertTrue(rules.isAllowed("http://www.domain.com/"));
 
-        rules = createRobotRules("Mozilla allowbot2 99.9", heritrixRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Mozilla allowbot2 99.9", heritrixRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/path"));
         assertTrue(rules.isAllowed("http://www.domain.com/"));
         assertFalse(rules.isAllowed("http://www.domain.com/foo"));
 
-        rules = createRobotRules("Mozilla denybot 99.9", heritrixRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Mozilla denybot 99.9", heritrixRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/path"));
         assertFalse(rules.isAllowed("http://www.domain.com/"));
         assertEquals(BaseRobotRules.UNSET_CRAWL_DELAY, rules.getCrawlDelay());
 
-        rules = createRobotRules("Mozilla anonbot 99.9", heritrixRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Mozilla anonbot 99.9", heritrixRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/path"));
         assertFalse(rules.isAllowed("http://www.domain.com/cgi-bin/foo.pl"));
 
-        rules = createRobotRules("Mozilla delaybot 99.9", heritrixRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Mozilla delaybot 99.9", heritrixRobotsTxt.getBytes(UTF_8));
         assertEquals(20000, rules.getCrawlDelay());
     }
 
     @Test
-    public void testCaseSensitivePaths() throws MalformedURLException, UnsupportedEncodingException {
+    public void testCaseSensitivePaths() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Allow: /AnyPage.html" + CRLF + "Allow: /somepage.html" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/AnyPage.html"));
         assertFalse(rules.isAllowed("http://www.domain.com/anypage.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/somepage.html"));
@@ -493,81 +493,81 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testEmptyDisallow() throws MalformedURLException, UnsupportedEncodingException {
+    public void testEmptyDisallow() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow:";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testEmptyAllow() throws MalformedURLException, UnsupportedEncodingException {
+    public void testEmptyAllow() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Allow:";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testMultiWildcard() throws MalformedURLException, UnsupportedEncodingException {
+    public void testMultiWildcard() {
         // Make sure we only take the first wildcard entry.
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: *" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testMultiMatches() throws MalformedURLException, UnsupportedEncodingException {
+    public void testMultiMatches() {
         // Make sure we only take the first record that matches.
         final String simpleRobotsTxt = "User-agent: crawlerbot" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: crawler" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("crawlerbot", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("crawlerbot", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testMultiAgentNames() throws MalformedURLException, UnsupportedEncodingException {
+    public void testMultiAgentNames() {
         // When there are more than one agent name on a line.
         final String simpleRobotsTxt = "User-agent: crawler1 crawler2" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /";
 
-        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testMultiWordAgentName() throws MalformedURLException, UnsupportedEncodingException {
+    public void testMultiWordAgentName() {
         // When the user agent name has a space in it.
         final String simpleRobotsTxt = "User-agent: Download Ninja" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /";
 
-        BaseRobotRules rules = createRobotRules("Download Ninja", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Download Ninja", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testUnsupportedFields() throws MalformedURLException, UnsupportedEncodingException {
+    public void testUnsupportedFields() {
         // When we have a new field type that we don't know about.
         final String simpleRobotsTxt = "User-agent: crawler1" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + "newfield: 234" + CRLF + "User-agent: crawler2" + CRLF + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
 
     @Test
-    public void testAcapFields() throws MalformedURLException, UnsupportedEncodingException {
+    public void testAcapFields() {
         final String robotsTxt = "acap-crawler: *" + CRLF + "acap-disallow-crawl: /ultima_ora/";
 
         SimpleRobotRulesParser parser = new SimpleRobotRulesParser();
-        parser.parseContent("url", robotsTxt.getBytes("UTF-8"), "text/plain", "foobot");
+        parser.parseContent("url", robotsTxt.getBytes(UTF_8), "text/plain", "foobot");
         assertEquals(0, parser.getNumWarnings());
     }
 
     @Test
-    public void testStatusCodeCreation() throws MalformedURLException {
+    public void testStatusCodeCreation() {
         BaseRobotRules rules;
 
         SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
@@ -600,34 +600,34 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testCrawlDelay() throws UnsupportedEncodingException {
+    public void testCrawlDelay() {
         final String delayRules1RobotsTxt = "User-agent: bixo" + CR + "Crawl-delay: 10" + CR + "User-agent: foobot" + CR + "Crawl-delay: 20" + CR + "User-agent: *" + CR + "Disallow:/baz" + CR;
 
-        BaseRobotRules rules = createRobotRules("bixo", delayRules1RobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("bixo", delayRules1RobotsTxt.getBytes(UTF_8));
         long crawlDelay = rules.getCrawlDelay();
         assertEquals("testing crawl delay for agent bixo - rule 1", 10000, crawlDelay);
 
         final String delayRules2RobotsTxt = "User-agent: foobot" + CR + "Crawl-delay: 20" + CR + "User-agent: *" + CR + "Disallow:/baz" + CR;
 
-        rules = createRobotRules("bixo", delayRules2RobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("bixo", delayRules2RobotsTxt.getBytes(UTF_8));
         crawlDelay = rules.getCrawlDelay();
         assertEquals("testing crawl delay for agent bixo - rule 2", BaseRobotRules.UNSET_CRAWL_DELAY, crawlDelay);
     }
 
     @Test
-    public void testBigCrawlDelay() throws MalformedURLException, UnsupportedEncodingException {
+    public void testBigCrawlDelay() {
         final String robotsTxt = "User-agent: *" + CR + "Crawl-delay: 3600" + CR + "Disallow:" + CR;
 
-        BaseRobotRules rules = createRobotRules("bixo", robotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("bixo", robotsTxt.getBytes(UTF_8));
         assertFalse("disallow all if huge crawl delay", rules.isAllowed("http://www.domain.com/"));
     }
 
     @Test
-    public void testBrokenKrugleRobotsTxtFile() throws MalformedURLException, UnsupportedEncodingException {
+    public void testBrokenKrugleRobotsTxtFile() {
         final String krugleRobotsTxt = "User-agent: *" + CR + "Disallow: /maintenance.html" + CR + "Disallow: /perl/" + CR + "Disallow: /cgi-bin/" + CR + "Disallow: /examples/" + CR
                         + "Crawl-delay: 3" + CR + "" + CR + "User-agent: googlebot" + CR + "Crawl-delay: 1" + CR + "" + CR + "User-agent: qihoobot" + CR + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
     }
 
@@ -650,10 +650,10 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
-    public void testFloatingPointCrawlDelay() throws MalformedURLException, UnsupportedEncodingException {
+    public void testFloatingPointCrawlDelay() {
         final String robotsTxt = "User-agent: *" + CR + "Crawl-delay: 0.5" + CR + "Disallow:" + CR;
 
-        BaseRobotRules rules = createRobotRules("bixo", robotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("bixo", robotsTxt.getBytes(UTF_8));
         assertEquals(500, rules.getCrawlDelay());
     }
 
@@ -752,7 +752,7 @@ public class SimpleRobotRulesParserTest {
     public void testAllowBeforeDisallow() throws Exception {
         final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /fish" + CRLF + "Allow: /fish" + CRLF;
 
-        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
 
         assertTrue(rules.isAllowed("http://www.fict.com/fish"));
     }
@@ -761,16 +761,16 @@ public class SimpleRobotRulesParserTest {
     public void testSpacesInMultipleUserAgentNames() throws Exception {
         final String simpleRobotsTxt = "User-agent: One, Two, Three" + CRLF + "Disallow: /" + CRLF + "" + CRLF + "User-agent: *" + CRLF + "Allow: /" + CRLF;
 
-        BaseRobotRules rules = createRobotRules("One", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("One", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
-        rules = createRobotRules("Two", simpleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Two", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
-        rules = createRobotRules("Three", simpleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Three", simpleRobotsTxt.getBytes(UTF_8));
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
-        rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes("UTF-8"));
+        rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt.getBytes(UTF_8));
         assertTrue(rules.isAllowed("http://www.fict.com/fish"));
     }
 
@@ -780,7 +780,7 @@ public class SimpleRobotRulesParserTest {
         final String simpleRobotsTxt = "User-agent: a" + CRLF + "Disallow: /content/dam/" + CRLF + CRLF + "User-agent: b" + CRLF + "Disallow: /content/dam/" + CRLF + CRLF + "User-agent: c" + CRLF
                         + "Disallow: /content/dam/" + CRLF + CRLF + CRLF + "Sitemap: https://wwwfoocom/sitemapxml";
 
-        BaseRobotRules rules = createRobotRules("a", simpleRobotsTxt.getBytes("UTF-8"));
+        BaseRobotRules rules = createRobotRules("a", simpleRobotsTxt.getBytes(UTF_8));
         assertEquals(1, rules.getSitemaps().size());
         assertEquals("https://wwwfoocom/sitemapxml", rules.getSitemaps().get(0));
     }

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -16,13 +16,14 @@
 
 package crawlercommons.sitemaps;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
@@ -59,7 +60,7 @@ public class SiteMapParserTest {
         scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append("<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">").append("<sitemap>")
                         .append("  <loc>http://www.example.com/sitemap1.xml.gz</loc>").append("  <lastmod>2004-10-01T18:23:17+00:00</lastmod>").append("</sitemap>").append("<sitemap>")
                         .append("  <loc>http://www.example.com/sitemap2.xml.gz</loc>").append("  <lastmod>2005-01-01</lastmod>").append("</sitemap>").append("</sitemapindex>");
-        byte[] content = scontent.toString().getBytes("UTF-8");
+        byte[] content = scontent.toString().getBytes(UTF_8);
         URL url = new URL("http://www.example.com/sitemapindex.xml");
 
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -95,7 +96,7 @@ public class SiteMapParserTest {
         SiteMapParser parser = new SiteMapParser();
         String contentType = "text/plain";
         String scontent = "http://www.example.com/catalog?item=1\nhttp://www.example.com/catalog?item=11";
-        byte[] content = scontent.getBytes("UTF-8");
+        byte[] content = scontent.getBytes(UTF_8);
         URL url = new URL("http://www.example.com/sitemap.txt");
 
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -110,7 +111,7 @@ public class SiteMapParserTest {
     public void testSitemapTXTWithXMLExt() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
         String scontent = "http://www.example.com/catalog?item=1\nhttp://www.example.com/catalog?item=11";
-        byte[] content = scontent.getBytes("UTF-8");
+        byte[] content = scontent.getBytes(UTF_8);
         URL url = new URL("http://www.example.com/sitemap.xml");
         String contentType = "text/plain";
 
@@ -173,7 +174,7 @@ public class SiteMapParserTest {
         scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">")
                         .append("<url><!-- This file is not a valid XML file --></url>").append("<url><loc> http://cs.harding.edu/fmccown/sitemaps/something.html</loc>")
                         .append("</url><!-- missing opening url tag --></url></urlset>");
-        byte[] content = scontent.toString().getBytes("UTF-8");
+        byte[] content = scontent.toString().getBytes(UTF_8);
         URL url = new URL("http://www.example.com/sitemapindex.xml");
 
         parser.parseSiteMap(contentType, content, url); // This Sitemap contains
@@ -257,7 +258,7 @@ public class SiteMapParserTest {
         StringBuilder scontent = new StringBuilder(1024);
         scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">").append("<url>")
                         .append("<loc>http://www.example.com/</loc>").append("</url>").append("</urlset>");
-        byte[] content = scontent.toString().getBytes("UTF-8");
+        byte[] content = scontent.toString().getBytes(UTF_8);
 
         URL url = new URL("http://www.example.com/subsection/sitemap.xml");
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -284,10 +285,11 @@ public class SiteMapParserTest {
      * 
      * See https://github.com/crawler-commons/crawler-commons/issues/87
      * 
-     * @throws Exception
+     * @throws IOException
+     * @throws UnknownFormatException
      */
     @Test
-    public void testRSS10SyndicationFormat() throws Exception {
+    public void testRSS10SyndicationFormat() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
 
         String contentType = "text/xml";
@@ -308,7 +310,7 @@ public class SiteMapParserTest {
                         .append("<link>http://www.example.com/pub/2000/08/09/xslt/xslt.html</link>")
                         .append("<description>Processing document inclusions with general XML tools can be problematic. This article proposes a way of preserving inclusion"
                                         + "information through SAX-based processing. </description> </item> </rdf:RDF>");
-        byte[] content = scontent.toString().getBytes("UTF-8");
+        byte[] content = scontent.toString().getBytes(UTF_8);
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
         assertEquals(false, asm.isIndex());
         assertEquals(true, asm instanceof SiteMap);
@@ -321,9 +323,8 @@ public class SiteMapParserTest {
     /**
      * Returns a good simple default XML sitemap as a byte array
      * 
-     * @throws UnsupportedEncodingException
      */
-    private byte[] getXMLSitemapAsBytes() throws UnsupportedEncodingException {
+    private byte[] getXMLSitemapAsBytes() {
         StringBuilder scontent = new StringBuilder(1024);
         scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">");
         scontent.append("<url>  <loc>").append(sitemapURLs[0]).append("</loc>  <lastmod>2005-01-01</lastmod>").append("  <changefreq>monthly</changefreq>").append("  <priority>0.8</priority>")
@@ -334,7 +335,7 @@ public class SiteMapParserTest {
         scontent.append("<url>  <loc><url><![CDATA[").append(sitemapURLs[4]).append("]]></url></loc>  <lastmod>2004-11-23</lastmod>").append("</url>");
         scontent.append("</urlset>");
 
-        return scontent.toString().getBytes("UTF-8");
+        return scontent.toString().getBytes(UTF_8);
     }
 
     private static String[] sitemapURLs = new String[] { "http://www.example.com/", "http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii",

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.text.SimpleDateFormat;
 import java.util.Date;

--- a/src/test/java/crawlercommons/sitemaps/SiteMapURLTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapURLTest.java
@@ -23,7 +23,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Created on 13/10/2014.


### PR DESCRIPTION
- replace String constants defining charsets by StandardCharset constants
  if available for given encoding and supported by called method
- remove unnecessary exceptions (UnsupportedEncodingException)