### PR TITLE
SAX parser does not extract URLs from Atom feeds, fixes #159

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -72,6 +72,9 @@ public class DelegatorHandler extends DefaultHandler {
         } else {
             elementStack.push(qName);
         }
+        if (delegate != null) {
+            delegate.startElement(uri, localName, qName, attributes);
+        }
     }
 
     private void startRootElement(String uri, String localName, String qName, Attributes attributes) {

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -23,6 +23,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedList;
 
+import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
@@ -66,6 +67,9 @@ class XMLHandler extends DelegatorHandler {
         sitemap = new SiteMap(url);
         sitemap.setType(SitemapType.XML);
         loc = new StringBuilder();
+    }
+
+    public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
     }
 
     public void endElement(String uri, String localName, String qName) throws SAXException {

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
@@ -184,9 +184,7 @@ public class SiteMapParserSAXTest {
     @Test
     public void testMissingLocSitemapIndexFile() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParserSAX();
-        File smFile = new File("src/test/resources/sitemaps/sitemap.index.xml");
-        InputStream is = new FileInputStream(smFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/sitemap.index.xml");
 
         URL url = new URL("http://www.example.com/sitemap.index.xml");
         AbstractSiteMap asm = parser.parseSiteMap(content, url);
@@ -200,9 +198,7 @@ public class SiteMapParserSAXTest {
     public void testSitemapGZ() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParserSAX();
         String contentType = "application/gzip";
-        File gzSitemapFile = new File("src/test/resources/sitemaps/xmlSitemap.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/xmlSitemap.gz");
 
         URL url = new URL("http://www.example.com/sitemap.xml.gz");
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -216,9 +212,7 @@ public class SiteMapParserSAXTest {
     public void testSitemapTextGZ() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParserSAX();
         String contentType = "application/gzip";
-        File gzSitemapFile = new File("src/test/resources/sitemaps/sitemap.txt.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = this.getResourceAsBytes("src/test/resources/sitemaps/sitemap.txt.gz");
 
         URL url = new URL("http://www.example.com/sitemap.txt.gz");
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -231,9 +225,7 @@ public class SiteMapParserSAXTest {
     @Test
     public void testSitemapGZMediaTypes() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParserSAX();
-        File gzSitemapFile = new File("src/test/resources/sitemaps/xmlSitemap.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/xmlSitemap.gz");
 
         final String[] GZ_CONTENT_TYPES = new String[] { "application/gzip", "application/x-gzip", "application/x-gunzip", "application/gzipped", "application/gzip-compressed", "gzip/document" };
         for (String contentType : GZ_CONTENT_TYPES) {
@@ -292,6 +284,17 @@ public class SiteMapParserSAXTest {
         sm = (SiteMap) asm;
         assertEquals(1, sm.getSiteMapUrls().size());
         assertFalse(sm.getSiteMapUrls().iterator().next().isValid());
+    }
+
+    @Test
+    public void testAtomFormat() throws UnknownFormatException, IOException {
+        SiteMapParser parser = new SiteMapParserSAX();
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/atom.xml");
+        URL url = new URL("http://example.org/atom.xml");
+
+        SiteMap sm = (SiteMap) parser.parseSiteMap(content, url);
+        assertEquals(1, sm.getSiteMapUrls().size());
+        assertEquals(new URL("http://example.org/2003/12/13/atom03"), sm.getSiteMapUrls().iterator().next().getUrl());
     }
 
     /**
@@ -413,6 +416,20 @@ public class SiteMapParserSAXTest {
         scontent.append("</urlset>");
 
         return scontent.toString().getBytes(UTF_8);
+    }
+
+    /**
+     * Read a test resource file and return its content as byte array.
+     *
+     * @param resourceName
+     *            path to the resource file
+     * @return byte content of the file
+     * @throws IOException
+     */
+    private byte[] getResourceAsBytes(String resourceName) throws IOException {
+        File file = new File(resourceName);
+        InputStream is = new FileInputStream(file);
+        return IOUtils.toByteArray(is);
     }
 
     private static String[] sitemapURLs = new String[] { "http://www.example.com/", "http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii",

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -185,9 +185,7 @@ public class SiteMapParserTest {
     @Test
     public void testMissingLocSitemapIndexFile() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
-        File smFile = new File("src/test/resources/sitemaps/sitemap.index.xml");
-        InputStream is = new FileInputStream(smFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/sitemap.index.xml");
 
         URL url = new URL("http://www.example.com/sitemap.index.xml");
         AbstractSiteMap asm = parser.parseSiteMap(content, url);
@@ -201,9 +199,7 @@ public class SiteMapParserTest {
     public void testSitemapGZ() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
         String contentType = "application/gzip";
-        File gzSitemapFile = new File("src/test/resources/sitemaps/xmlSitemap.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/xmlSitemap.gz");
 
         URL url = new URL("http://www.example.com/sitemap.xml.gz");
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -217,9 +213,7 @@ public class SiteMapParserTest {
     public void testSitemapTextGZ() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
         String contentType = "application/gzip";
-        File gzSitemapFile = new File("src/test/resources/sitemaps/sitemap.txt.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = this.getResourceAsBytes("src/test/resources/sitemaps/sitemap.txt.gz");
 
         URL url = new URL("http://www.example.com/sitemap.txt.gz");
         AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
@@ -232,9 +226,7 @@ public class SiteMapParserTest {
     @Test
     public void testSitemapGZMediaTypes() throws UnknownFormatException, IOException {
         SiteMapParser parser = new SiteMapParser();
-        File gzSitemapFile = new File("src/test/resources/sitemaps/xmlSitemap.gz");
-        InputStream is = new FileInputStream(gzSitemapFile);
-        byte[] content = IOUtils.toByteArray(is);
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/xmlSitemap.gz");
 
         final String[] GZ_CONTENT_TYPES = new String[] { "application/gzip", "application/x-gzip", "application/x-gunzip", "application/gzipped", "application/gzip-compressed", "gzip/document" };
         for (String contentType : GZ_CONTENT_TYPES) {
@@ -293,6 +285,17 @@ public class SiteMapParserTest {
         sm = (SiteMap) asm;
         assertEquals(1, sm.getSiteMapUrls().size());
         assertFalse(sm.getSiteMapUrls().iterator().next().isValid());
+    }
+
+    @Test
+    public void testAtomFormat() throws UnknownFormatException, IOException {
+        SiteMapParser parser = new SiteMapParser();
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/atom.xml");
+        URL url = new URL("http://example.org/atom.xml");
+
+        SiteMap sm = (SiteMap) parser.parseSiteMap(content, url);
+        assertEquals(1, sm.getSiteMapUrls().size());
+        assertEquals(new URL("http://example.org/2003/12/13/atom03"), sm.getSiteMapUrls().iterator().next().getUrl());
     }
 
     /**
@@ -416,6 +419,20 @@ public class SiteMapParserTest {
         scontent.append("</urlset>");
 
         return scontent.toString().getBytes(UTF_8);
+    }
+
+    /**
+     * Read a test resource file and return its content as byte array.
+     *
+     * @param resourceName
+     *            path to the resource file
+     * @return byte content of the file
+     * @throws IOException
+     */
+    private byte[] getResourceAsBytes(String resourceName) throws IOException {
+        File file = new File(resourceName);
+        InputStream is = new FileInputStream(file);
+        return IOUtils.toByteArray(is);
     }
 
     private static String[] sitemapURLs = new String[] { "http://www.example.com/", "http://www.example.com/catalog?item=12&amp;desc=vacation_hawaii",

--- a/src/test/resources/sitemaps/atom.xml
+++ b/src/test/resources/sitemaps/atom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- from:
+     https://validator.w3.org/feed/docs/atom.html
+     https://en.wikipedia.org/wiki/Atom_(standard)
+-->
+<feed xmlns="http://www.w3.org/2005/Atom">
+
+	<title>Example Feed</title>
+	<subtitle>A subtitle.</subtitle>
+	<link href="http://example.org/feed/" rel="self" />
+	<link href="http://example.org/" />
+	<id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
+	<updated>2003-12-13T18:30:02Z</updated>
+
+
+	<entry>
+		<title>Atom-Powered Robots Run Amok</title>
+		<link href="http://example.org/2003/12/13/atom03" />
+		<link rel="alternate" type="text/html" href="http://example.org/2003/12/13/atom03.html"/>
+		<link rel="edit" href="http://example.org/2003/12/13/atom03/edit"/>
+		<id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+		<updated>2003-12-13T18:30:02Z</updated>
+		<summary>Some text.</summary>
+		<content type="xhtml">
+			<div xmlns="http://www.w3.org/1999/xhtml">
+				<p>This is the entry content.</p>
+			</div>
+		</content>
+		<author>
+			<name>John Doe</name>
+			<email>johndoe@example.com</email>
+		</author>
+	</entry>
+
+</feed>


### PR DESCRIPTION
- call delegated method startElement(...) from DelegatorHandler
- add heuristics to select link URL
- add Atom feed unit test
- add static method to encapsulate reading of test resource files