### PR TITLE
SAX parser to stop URL at closing </loc> fixes #153

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -72,7 +72,20 @@ class XMLHandler extends DelegatorHandler {
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         // flush any unclosed or missing URL element
         if (loc.length() > 0 && ("loc".equals(qName) || "url".equals(qName))) {
-            maybeAddSiteMapUrl();
+            // check whether loc isn't white space only
+            for (int i = 0; i < loc.length(); i++) {
+                if (!Character.isWhitespace(loc.charAt(i))) {
+                    maybeAddSiteMapUrl();
+                    return;
+                }
+            }
+            loc = new StringBuilder();
+            if ("url".equals(qName)) {
+                // reset also attributes
+                lastMod = null;
+                changeFreq = null;
+                priority = null;
+            }
         }
     }
 


### PR DESCRIPTION
- on opening <loc> and <url> assume forgotten closing </url> tag
  only if there is more than white space in the buffer