### PR TITLE
ISSUE #166 RSS parser ignores item's pubDate

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
+++ b/src/main/java/crawlercommons/sitemaps/AbstractSiteMap.java
@@ -61,27 +61,18 @@ public abstract class AbstractSiteMap {
         }
     };
 
-    protected static final ThreadLocal<DateFormat> RFC822_FULLDATE_FORMAT = new ThreadLocal<DateFormat>() {
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ROOT);
-        }
-    };
-
-    protected static final ThreadLocal<DateFormat> RFC822_NO_WEEKDAY_DATE_FORMAT = new ThreadLocal<DateFormat>() {
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.ROOT);
-        }
-    };
-
-    protected static final ThreadLocal<DateFormat> RFC822_SHORT_YEAR_DATE_FORMAT = new ThreadLocal<DateFormat>() {
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("EEE, dd MMM yy HH:mm:ss Z", Locale.ROOT);
-        }
-    };
-
-    protected static final ThreadLocal<DateFormat> RFC822_SHORTDATE_FORMAT = new ThreadLocal<DateFormat>() {
-        protected DateFormat initialValue() {
-            return new SimpleDateFormat("dd MMM yy HH:mm:ss Z", Locale.ROOT);
+    /**
+     * The set of date-time formats which could be used as pubDate in RSS.
+     */
+    private static final ThreadLocal<DateFormat[]> RSS_DATE_FORMATS = new ThreadLocal<DateFormat[]>() {
+        @Override
+        protected DateFormat[] initialValue() {
+            return new DateFormat[] {
+                    new SimpleDateFormat("EEE, dd MMM yy HH:mm:ss Z", Locale.ROOT),
+                    new SimpleDateFormat("dd MMM yy HH:mm:ss Z", Locale.ROOT),
+                    new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.ROOT),
+                    new SimpleDateFormat("dd MMM yyyy HH:mm:ss Z", Locale.ROOT)
+            };
         }
     };
 
@@ -213,11 +204,6 @@ public abstract class AbstractSiteMap {
         }
     }
 
-    @SuppressWarnings("unchecked")
-    private static ThreadLocal<DateFormat>[] RSS_DATE_FORMATS = new ThreadLocal[] {
-            RFC822_SHORT_YEAR_DATE_FORMAT, RFC822_SHORTDATE_FORMAT, RFC822_FULLDATE_FORMAT, RFC822_NO_WEEKDAY_DATE_FORMAT
-    };
-
     /**
      * Converts pubDate of RSS to the string representation which could be parsed
      * in {@link #convertToDate(String)} method.
@@ -232,9 +218,9 @@ public abstract class AbstractSiteMap {
             return null;
         }
         Date date = null;
-        for (ThreadLocal<DateFormat> format : RSS_DATE_FORMATS) {
+        for (DateFormat format : RSS_DATE_FORMATS.get()) {
             try {
-                date = format.get().parse(pubDate);
+                date = format.parse(pubDate);
                 break;
             } catch (ParseException ex) {
                 // try next one

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -695,8 +695,9 @@ public class SiteMapParser {
         Element elem = (Element) list.item(0);
 
         // Treat publication date as last mod (Tue, 10 Jun 2003 04:00:00 GMT)
-        String lastMod = getElementValue(elem, "pubDate");
-        LOG.debug("lastMod = ", lastMod);
+        String channelLastMod = AbstractSiteMap.normalizeRSSTimestamp(getElementValue(elem, "pubDate"));
+        LOG.debug("channel's lastMod = {}", channelLastMod);
+        sitemap.setLastModified(channelLastMod);
 
         list = doc.getElementsByTagName("item");
         // Loop through the <item>s
@@ -706,8 +707,9 @@ public class SiteMapParser {
             if (n.getNodeType() == Node.ELEMENT_NODE) {
                 elem = (Element) n;
                 String link = getElementValue(elem, "link");
+                String itemLastMod = AbstractSiteMap.normalizeRSSTimestamp(getElementValue(elem, "pubDate"));
 
-                addUrlIntoSitemap(link, sitemap, lastMod, null, null, i);
+                addUrlIntoSitemap(link, sitemap, itemLastMod, null, null, i);
             }
         }
     }

--- a/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
+++ b/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
@@ -61,4 +61,16 @@ public class AbstractSiteMapTest {
 
     }
 
+    @Test
+    public void testRssDateNormalyzing() {
+        assertNull(AbstractSiteMap.normalizeRSSTimestamp(null));
+        assertEquals("incorrect", AbstractSiteMap.normalizeRSSTimestamp("incorrect"));
+
+        assertEquals("2017-01-05T12:34:50+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 12:34:50 GMT"));
+        assertEquals("2017-01-05T12:34:51+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 13:34:51 +0100"));
+        assertEquals("2017-01-05T12:34:52+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 2017 11:34:52 -0100"));
+        assertEquals("2017-01-05T12:34:53+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 17 12:34:53 GMT"));
+        assertEquals("2017-01-05T12:34:54+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 17 12:34:54 GMT"));
+    }
+
 }

--- a/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
+++ b/src/test/java/crawlercommons/sitemaps/AbstractSiteMapTest.java
@@ -66,11 +66,11 @@ public class AbstractSiteMapTest {
         assertNull(AbstractSiteMap.normalizeRSSTimestamp(null));
         assertEquals("incorrect", AbstractSiteMap.normalizeRSSTimestamp("incorrect"));
 
-        assertEquals("2017-01-05T12:34:50+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 12:34:50 GMT"));
-        assertEquals("2017-01-05T12:34:51+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 13:34:51 +0100"));
-        assertEquals("2017-01-05T12:34:52+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 2017 11:34:52 -0100"));
-        assertEquals("2017-01-05T12:34:53+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 17 12:34:53 GMT"));
-        assertEquals("2017-01-05T12:34:54+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 17 12:34:54 GMT"));
+        assertEquals("Full date-time with named timezone", "2017-01-05T12:34:50+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 12:34:50 GMT"));
+        assertEquals("Full date-time with local differental", "2017-01-05T12:34:51+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 2017 13:34:51 +0100"));
+        assertEquals("Date-time without week day", "2017-01-05T12:34:52+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 2017 11:34:52 -0100"));
+        assertEquals("Date-time without week day and two-digit year", "2017-01-05T12:34:53+0000", AbstractSiteMap.normalizeRSSTimestamp("05 Jan 17 12:34:53 GMT"));
+        assertEquals("Date-time with two-digit year", "2017-01-05T12:34:54+0000", AbstractSiteMap.normalizeRSSTimestamp("Thu, 05 Jan 17 12:34:54 GMT"));
     }
 
 }

--- a/src/test/resources/rss/xmlRss_pubDate.xml
+++ b/src/test/resources/rss/xmlRss_pubDate.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0"  xmlns:atom="http://www.w3.org/2005/Atom">
+
+    <channel>
+        <title>Main channel</title>
+        <pubDate>Thu, 05 Jan 2017 12:34:50 GMT</pubDate>
+        <link>http://www.example.com/rss.xml</link>
+        <item>
+            <title><![CDATA[News number 1]]></title>
+            <link>http://www.example.com/article_1</link>
+            <pubDate>Thu, 05 Jan 2017 13:34:51 +0100</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 2]]></title>
+            <link>http://www.example.com/article_2</link>
+            <pubDate>Thu, 05 Jan 17 13:34:52 +0100</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 3]]></title>
+            <link>http://www.example.com/article_3</link>
+            <pubDate>05 Jan 2017 13:34:53 +0100</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 4]]></title>
+            <link>http://www.example.com/article_4</link>
+            <pubDate>05 Jan 17 13:34:54 +0100</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 5 incomplete pub date]]></title>
+            <link>http://www.example.com/article_5</link>
+            <pubDate>05 Jan 17 13:34:55</pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 6 empty pub date]]></title>
+            <link>http://www.example.com/article_6</link>
+            <pubDate></pubDate>
+        </item>
+        <item>
+            <title><![CDATA[News number 7 missing pub date]]></title>
+            <link>http://www.example.com/article_7</link>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
* Converts RSS timestamp format to w3c format
* Use pubDate of item in new SiteMapURL creation