### PR TITLE
Sitemap SAX parser mangles sitemap URLs in sitemap index, fixes #169

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.9-SNAPSHOT
+- [Sitemaps] Sitemap SAX parsing mangles target URLs (jnioche, sebastian-nagel) #169
 - [Sitemaps] RSS parser ignores pubDate of link (MichealKum via kkrugler) #166
 
 Release 0.8 (2017-06-09)

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
@@ -56,9 +56,11 @@ public class SiteMapParserSAXTest {
         SiteMapParser parser = new SiteMapParserSAX();
         String contentType = "text/xml";
         StringBuilder scontent = new StringBuilder(1024);
-        scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>").append("<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">").append("<sitemap>")
-                        .append("  <loc>http://www.example.com/sitemap1.xml.gz</loc>").append("  <lastmod>2004-10-01T18:23:17+00:00</lastmod>").append("</sitemap>").append("<sitemap>")
-                        .append("  <loc>http://www.example.com/sitemap2.xml.gz</loc>").append("  <lastmod>2005-01-01</lastmod>").append("</sitemap>").append("</sitemapindex>");
+        scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n").append("<sitemapindex xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n").append(" <sitemap>\n")
+                        .append("  <loc>http://www.example.com/sitemap1.xml.gz</loc>\n").append("  <lastmod><![CDATA[2004-10-01T18:23:17+00:00]]></lastmod>\n").append(" </sitemap>\n")
+                        .append("<sitemap>\n").append("  <loc>http://www.example.com/sitemap2.xml.gz</loc>\n").append("  <lastmod>2005-01-01</lastmod>\n").append(" </sitemap>\n")
+                        .append("<sitemap>\n").append("  <loc>http://www.example.com/dynsitemap?date=now&amp;all=true</loc>\n").append(" </sitemap>\n").append("<sitemap>\n")
+                        .append("  <loc>http://www.example.com/dynsitemap<![CDATA[?date=lastyear&all=false]]></loc>\n").append(" </sitemap>\n").append("</sitemapindex>");
         byte[] content = scontent.toString().getBytes(UTF_8);
         URL url = new URL("http://www.example.com/sitemapindex.xml");
 
@@ -67,7 +69,7 @@ public class SiteMapParserSAXTest {
         assertEquals(true, asm instanceof SiteMapIndex);
 
         SiteMapIndex smi = (SiteMapIndex) asm;
-        assertEquals(2, smi.getSitemaps().size());
+        assertEquals(4, smi.getSitemaps().size());
 
         AbstractSiteMap currentSiteMap = smi.getSitemap(new URL("http://www.example.com/sitemap1.xml.gz"));
         assertNotNull(currentSiteMap);
@@ -80,6 +82,14 @@ public class SiteMapParserSAXTest {
         assertNotNull(currentSiteMap);
         assertEquals("http://www.example.com/sitemap2.xml.gz", currentSiteMap.getUrl().toString());
         assertEquals(SiteMap.convertToDate("2005-01-01"), currentSiteMap.getLastModified());
+
+        currentSiteMap = smi.getSitemap(new URL("http://www.example.com/dynsitemap?date=now&all=true"));
+        assertNotNull("<loc> with entities not found", currentSiteMap);
+        assertEquals("http://www.example.com/dynsitemap?date=now&all=true", currentSiteMap.getUrl().toString());
+
+        currentSiteMap = smi.getSitemap(new URL("http://www.example.com/dynsitemap?date=lastyear&all=false"));
+        assertNotNull("<loc> with CDATA not found", currentSiteMap);
+        assertEquals("http://www.example.com/dynsitemap?date=lastyear&all=false", currentSiteMap.getUrl().toString());
     }
 
     @Test
@@ -192,6 +202,8 @@ public class SiteMapParserSAXTest {
         assertEquals(true, asm instanceof SiteMapIndex);
         SiteMapIndex sm = (SiteMapIndex) asm;
         assertEquals(15, sm.getSitemaps().size());
+        String sitemap = "https://example.com/sitemap.jss?portalCode=10260&lang=en";
+        assertNotNull("Sitemap " + sitemap + " not found in sitemap index", sm.getSitemap(new URL(sitemap)));
     }
 
     @Test
@@ -420,7 +432,7 @@ public class SiteMapParserSAXTest {
 
     /**
      * Read a test resource file and return its content as byte array.
-     *
+     * 
      * @param resourceName
      *            path to the resource file
      * @return byte content of the file


### PR DESCRIPTION
- completely add sitemap URLs from sitemap index if URL contains
  XML entities or CDATA
- update unit tests to cover this problem