### PR TITLE
Add namespace aware DOM/SAX parsing for XML Sitemaps.

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/Namespace.java
+++ b/src/main/java/crawlercommons/sitemaps/Namespace.java
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2016 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.sitemaps;
+
+/**
+ * supported sitemap formats:
+ * https://www.sitemaps.org/protocol.html#otherformats
+ */
+public class Namespace {
+    
+	public static final String SITEMAP = "http://www.sitemaps.org/schemas/sitemap/0.9";
+    
+    /** 
+     * RSS and Atom sitemap formats do not have strict definition.
+     * But if we do not parse as namespace aware, then RSS/Atom files that choose to 
+     * use namespaces will break.
+     * The relaxed compromise for RSS/Atom is to always parse as "namespace aware", 
+     * but we will only match elements by the localName, accepting any element namespace.  
+    */
+    public static final String RSS_2_0 = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    public static final String ATOM_0_3 = "http://purl.org/atom/ns#";
+    public static final String ATOM_1_0 = "http://www.w3.org/2005/Atom";
+
+}
+

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParserSAX.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParserSAX.java
@@ -74,7 +74,7 @@ public class SiteMapParserSAX extends SiteMapParser {
     private static final List<MediaType> XML_MEDIA_TYPES = new ArrayList<>();
     private static final List<MediaType> TEXT_MEDIA_TYPES = new ArrayList<>();
     private static final List<MediaType> GZ_MEDIA_TYPES = new ArrayList<>();
-
+    
     static {
         initMediaTypes();
     }
@@ -356,9 +356,14 @@ public class SiteMapParserSAX extends SiteMapParser {
     protected AbstractSiteMap processXml(URL sitemapUrl, InputSource is) throws UnknownFormatException {
 
         SAXParserFactory factory = SAXParserFactory.newInstance();
+        
         // disable validation and avoid that remote DTDs, schemas, etc. are fetched
         factory.setValidating(false);
         factory.setXIncludeAware(false);
+        
+        // support the use of an explicit namespace. 
+        factory.setNamespaceAware(true);
+        
         try {
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         } catch (Exception e) {

--- a/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
@@ -78,11 +78,11 @@ class AtomHandler extends DelegatorHandler {
     }
 
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        if ("entry".equals(qName)) {
+        if ("entry".equals(localName)) {
             loc = null;
             lastMod = null;
             rel = null;
-        } else if ("link".equals(qName)) {
+        } else if ("link".equals(localName)) {
             String href = attributes.getValue("href");
             if (href == null)
                 return;
@@ -114,9 +114,9 @@ class AtomHandler extends DelegatorHandler {
     }
 
     public void characters(char[] ch, int start, int length) throws SAXException {
-        String qName = super.currentElement();
+        String localName = super.currentElement();
         String value = String.valueOf(ch, start, length);
-        if ("updated".equals(qName)) {
+        if ("updated".equals(localName)) {
             lastMod = value;
         }
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -29,6 +29,7 @@ import org.xml.sax.SAXParseException;
 
 import crawlercommons.sitemaps.AbstractSiteMap;
 import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
 import crawlercommons.sitemaps.SiteMapURL;
 
@@ -70,43 +71,47 @@ class XMLHandler extends DelegatorHandler {
     }
 
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        // flush any unclosed or missing URL element
-        if (loc.length() > 0 && ("loc".equals(qName) || "url".equals(qName))) {
-            // check whether loc isn't white space only
-            for (int i = 0; i < loc.length(); i++) {
-                if (!Character.isWhitespace(loc.charAt(i))) {
-                    maybeAddSiteMapUrl();
-                    return;
-                }
-            }
-            loc = new StringBuilder();
-            if ("url".equals(qName)) {
-                // reset also attributes
-                lastMod = null;
-                changeFreq = null;
-                priority = null;
-            }
+        // flush any unclosed or missing URL element    	
+        if ( Namespace.SITEMAP.equals(uri) ) {
+	        if (loc.length() > 0 && ("loc".equals(localName) || "url".equals(localName))) {
+	            // check whether loc isn't white space only
+	            for (int i = 0; i < loc.length(); i++) {
+	                if (!Character.isWhitespace(loc.charAt(i))) {
+	                    maybeAddSiteMapUrl();
+	                    return;
+	                }
+	            }
+	            loc = new StringBuilder();
+	            if ("url".equals(localName)) {
+	                // reset also attributes
+	                lastMod = null;
+	                changeFreq = null;
+	                priority = null;
+	            }
+	        }
         }
     }
 
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if ("url".equals(qName) && "urlset".equals(currentElementParent())) {
-            maybeAddSiteMapUrl();
-        } else if ("urlset".equals(qName)) {
-            sitemap.setProcessed(true);
+        if ( Namespace.SITEMAP.equals(uri) ) {
+	        if ("url".equals(localName) && "urlset".equals(currentElementParent())) {
+	            maybeAddSiteMapUrl();
+	        } else if ("urlset".equals(localName)) {
+	            sitemap.setProcessed(true);
+	        }
         }
     }
 
     public void characters(char[] ch, int start, int length) throws SAXException {
-        String qName = super.currentElement();
+        String localName = super.currentElement();
         String value = String.valueOf(ch, start, length);
-        if ("loc".equals(qName) || "url".equals(qName)) {
+        if ("loc".equals(localName) || "url".equals(localName)) {
             loc.append(value);
-        } else if ("changefreq".equals(qName)) {
+        } else if ("changefreq".equals(localName)) {
             changeFreq = value;
-        } else if ("lastmod".equals(qName)) {
+        } else if ("lastmod".equals(localName)) {
             lastMod = value;
-        } else if ("priority".equals(qName)) {
+        } else if ("priority".equals(localName)) {
             priority = value;
         }
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
@@ -28,6 +28,7 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import crawlercommons.sitemaps.AbstractSiteMap;
+import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
 import crawlercommons.sitemaps.SiteMapIndex;
 import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
@@ -70,12 +71,14 @@ class XMLIndexHandler extends DelegatorHandler {
     }
 
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if ("sitemap".equals(currentElement())) {
-            maybeAddSiteMap();
-        } else if ("sitemapindex".equals(currentElement())) {
-            sitemap.setProcessed(true);
-        } else if ("loc".equals(currentElement())) {
-            locClosed = true;
+        if ( Namespace.SITEMAP.equals(uri) ) {
+	        if ("sitemap".equals(currentElement())) {
+	            maybeAddSiteMap();
+	        } else if ("sitemapindex".equals(currentElement())) {
+	            sitemap.setProcessed(true);
+	        } else if ("loc".equals(currentElement())) {
+	            locClosed = true;
+	        }
         }
     }
 

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserSAXTest.java
@@ -36,6 +36,8 @@ import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
+
 import static org.junit.Assert.*;
 
 @RunWith(JUnit4.class)
@@ -92,6 +94,22 @@ public class SiteMapParserSAXTest {
         assertEquals("http://www.example.com/dynsitemap?date=lastyear&all=false", currentSiteMap.getUrl().toString());
     }
 
+    @Test
+    public void testSitemapWithNamespace() throws UnknownFormatException, IOException {
+        SiteMapParser parser = new SiteMapParserSAX();
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/sitemap.ns.xml");
+
+        URL url = new URL("http://www.example.com/sitemap.ns.xml");
+        AbstractSiteMap asm = parser.parseSiteMap(content, url);
+        assertEquals(SitemapType.XML, asm.getType());
+        assertEquals(true, asm instanceof SiteMap);
+        assertEquals(true, asm.isProcessed());
+        SiteMap sm = (SiteMap) asm;
+
+        assertEquals(2, sm.getSiteMapUrls().size());
+        assertEquals(SiteMapURL.ChangeFrequency.DAILY, sm.getSiteMapUrls().iterator().next().getChangeFrequency());    
+    }
+    
     @Test
     public void testFullDateFormat() {
         SimpleDateFormat format = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm+hh:00", Locale.ROOT);

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -95,6 +95,22 @@ public class SiteMapParserTest {
         assertNotNull("<loc> with CDATA not found", currentSiteMap);
         assertEquals("http://www.example.com/dynsitemap?date=lastyear&all=false", currentSiteMap.getUrl().toString());
     }
+    
+    @Test
+    public void testSitemapWithNamespace() throws UnknownFormatException, IOException {
+        SiteMapParser parser = new SiteMapParser();
+        byte[] content = getResourceAsBytes("src/test/resources/sitemaps/sitemap.ns.xml");
+
+        URL url = new URL("http://www.example.com/sitemap.ns.xml");
+        AbstractSiteMap asm = parser.parseSiteMap(content, url);
+        assertEquals(SitemapType.XML, asm.getType());
+        assertEquals(true, asm instanceof SiteMap);
+        assertEquals(true, asm.isProcessed());
+        SiteMap sm = (SiteMap) asm;
+
+        assertEquals(2, sm.getSiteMapUrls().size());
+        assertEquals(SiteMapURL.ChangeFrequency.DAILY, sm.getSiteMapUrls().iterator().next().getChangeFrequency());    
+    }
 
     @Test
     public void testFullDateFormat() {

--- a/src/test/resources/sitemaps/sitemap.ns.xml
+++ b/src/test/resources/sitemaps/sitemap.ns.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<sit:urlset xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:sit="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml link.xsd http://www.google.com/schemas/sitemap-video/1.1 video.xsd http://www.sitemaps.org/schemas/sitemap/0.9 sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 image.xsd">
+    <sit:url>
+        <sit:loc>http://www.example.com/1</sit:loc>
+        <sit:changefreq>daily</sit:changefreq>
+    </sit:url>
+    <sit:url>
+        <sit:loc>http://www.example.com/2</sit:loc>
+        <sit:changefreq>daily</sit:changefreq>
+    </sit:url>
+</sit:urlset>


### PR DESCRIPTION
Add namespace aware DOM/SAX parsing for XML Sitemaps.  RSS and Atom parsing is also namespace aware, but finding elements has been left "relaxed" by only matching on the element "localName" (legacy behavior).

Here is test xml that was failing:
```XML
<?xml version="1.0" encoding="UTF-8" standalone="no"?>
<sit:urlset xmlns:image="http://www.google.com/schemas/sitemap-image/1.1" xmlns:video="http://www.google.com/schemas/sitemap-video/1.1" xmlns:sit="http://www.sitemaps.org/schemas/sitemap/0.9" xmlns:xhtml="http://www.w3.org/1999/xhtml" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/1999/xhtml link.xsd http://www.google.com/schemas/sitemap-video/1.1 video.xsd http://www.sitemaps.org/schemas/sitemap/0.9 sitemap.xsd http://www.google.com/schemas/sitemap-image/1.1 image.xsd">
    <sit:url>
        <sit:loc>http://www.example.com/1</sit:loc>
        <sit:changefreq>daily</sit:changefreq>
    </sit:url>
    <sit:url>
        <sit:loc>http://www.example.com/2</sit:loc>
        <sit:changefreq>daily</sit:changefreq>
    </sit:url>
</sit:urlset>
```
