### PR TITLE
EffectiveTldFinder to parse Internationalized Domain Names (IDN)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 Crawler-Commons Change Log
 
 Current Development 0.10-SNAPSHOT (yyyy-mm-dd)
+- EffectiveTldFinder to parse Internationalized Domain Names (sebastian-nagel) #179
+- Add main() to EffectiveTldFinder (sebastian-nagel) #187
 - Handle new suffixes in PaidLevelDomain (kkrugler) #183
 
 Release 0.9 (2017-10-27)

--- a/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
+++ b/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
@@ -304,6 +304,7 @@ public class EffectiveTldFinder {
         int etldStartPos = res.offset - 1;
         if (hostname.charAt(etldStartPos) != DOT) {
             // should not happen: no dot before TLD
+            LOGGER.debug("No dot before eTLD {} in {}", hostname.substring(res.offset), hostname);
             return (strict ? null : hostname);
         }
         int start = 0;
@@ -311,6 +312,7 @@ public class EffectiveTldFinder {
         while ((pos = hostname.indexOf(DOT, start)) != -1) {
             if (pos == start) {
                 // there must be at least one character between two dots
+                LOGGER.debug("Two immediately consecutive dots in hostname: {}", hostname);
                 return (strict ? null : hostname);
             }
             if (pos >= etldStartPos)

--- a/src/main/java/crawlercommons/domains/SuffixTrie.java
+++ b/src/main/java/crawlercommons/domains/SuffixTrie.java
@@ -1,3 +1,19 @@
+/**
+ * Copyright 2016 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package crawlercommons.domains;
 
 import java.util.ArrayList;

--- a/src/main/java/crawlercommons/domains/SuffixTrie.java
+++ b/src/main/java/crawlercommons/domains/SuffixTrie.java
@@ -1,0 +1,201 @@
+package crawlercommons.domains;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class SuffixTrie<V> {
+
+    protected Node<V> root;
+
+    protected static class Node<V> {
+        /** sorted list of characters leading to children */
+        char[] chars = {};
+        @SuppressWarnings("unchecked")
+        Node<V>[] children = new Node[0];
+        V value = null;
+
+        public Node<V> getChild(char c) {
+            int pos = Arrays.binarySearch(chars, c);
+            if (pos >= 0) {
+                return children[pos];
+            }
+            return null;
+        }
+
+        public Node<V> addChild(char c, V value) {
+            int pos = Arrays.binarySearch(chars, c);
+            Node<V> child;
+            if (pos >= 0) {
+                child = children[pos];
+            } else {
+                child = new Node<V>();
+                char[] new_chars = new char[chars.length + 1];
+                @SuppressWarnings("unchecked")
+                Node<V>[] new_children = new Node[children.length + 1];
+                pos = -pos - 1;
+                new_chars[pos] = c;
+                new_children[pos] = child;
+                for (int i = 0; i < chars.length; i++) {
+                    if (i < pos) {
+                        new_chars[i] = chars[i];
+                        new_children[i] = children[i];
+                    } else if (i >= pos) {
+                        new_chars[i + 1] = chars[i];
+                        new_children[i + 1] = children[i];
+                    }
+                }
+                this.chars = new_chars;
+                this.children = new_children;
+            }
+            if (value != null) {
+                child.value = value;
+            }
+            return child;
+        }
+    }
+
+    public SuffixTrie() {
+        root = new Node<V>();
+    }
+
+    /**
+     * Insert a string and an associated value into the trie. If the string is
+     * already present in the trie, the existing value is replaced by the new
+     * value.
+     * 
+     * @param suffix
+     *            suffix string inserted into trie
+     * @param value
+     *            value associated with string
+     * @return previous value associated with string or null if there was no
+     *         previous value
+     */
+    public V put(String suffix, V value) {
+        V res = null;
+        if (suffix.isEmpty()) {
+            res = (V) root.value;
+            root.value = value;
+            return res;
+        }
+        Node<V> node = root;
+        for (int i = suffix.length() - 1; i > 0; i--) {
+            node = node.addChild(suffix.charAt(i), null);
+        }
+        Node<V> resNode = node.getChild(suffix.charAt(0));
+        if (resNode == null) {
+            node.addChild(suffix.charAt(0), value);
+            return null;
+        } else {
+            node.addChild(suffix.charAt(0), value);
+            return resNode.value;
+        }
+    }
+
+    /**
+     * Get value associated with suffix string in trie.
+     * 
+     * @param suffix
+     *            suffix string searched in trie
+     * @return value if suffix is found in trie, null otherwise
+     */
+    public V get(String suffix) {
+        if (suffix.isEmpty()) {
+            return root.value;
+        }
+        ;
+        Node<V> node = root;
+        for (int i = suffix.length() - 1; i >= 0; i--) {
+            node = node.getChild(suffix.charAt(i));
+            if (node == null) {
+                return null;
+            }
+        }
+        return node.value;
+    }
+
+    /**
+     * Checks whether trie contains a suffix string.
+     * 
+     * @param suffix
+     *            suffix string searched in trie
+     * @return true if suffix is found in trie
+     */
+    public boolean contains(String suffix) {
+        return get(suffix) != null;
+    }
+
+    /**
+     * Wrapper for results when a string is checked for suffixes contained in
+     * the suffix trie.
+     */
+    public static class LookupResult<V> {
+        /**
+         * Offset from beginning of lookup string, the matched suffix is the
+         * substring from offset until end of lookup string.
+         */
+        int offset;
+        /** Value associated with suffix string. */
+        V value;
+
+        public LookupResult(int offset, V value) {
+            this.offset = offset;
+            this.value = value;
+        }
+    }
+
+    /**
+     * Match the longest suffix of a string contained in trie.
+     * 
+     * @param string
+     *            to be checked for a contained (longest) suffix
+     * @return lookup result or null if no suffix is found
+     */
+    protected LookupResult<V> getLongestSuffix(String string) {
+      Node<V> node = root;
+      V resValue = null;
+      int offset = -1;
+      if (node.value != null) {
+          // trie contains empty string
+          offset = string.length();
+          resValue = node.value;
+      }
+      for (int i = string.length() - 1; i >= 0; i--) {
+          node = node.getChild(string.charAt(i));
+          if (node == null) {
+              break;
+          } else if (node.value != null) {
+              offset = i;
+              resValue = node.value;
+          }
+      }
+      if (offset != -1) {
+          return new LookupResult<>(offset, resValue);
+      }
+      return null;
+    }
+
+    /**
+     * Match all suffixes of a string contained in trie.
+     * 
+     * @param string
+     *            string to be checked for suffixes contained in trie
+     * @return list of suffix lookup results, from shortest to longest
+     */
+    protected List<LookupResult<V>> getSuffixes(String string) {
+        List<LookupResult<V>> res = new ArrayList<>();
+        Node<V> node = root;
+        if (node.value != null) {
+            res.add(new LookupResult<V>(string.length(), node.value));
+        }
+        for (int i = string.length() - 1; i >= 0; i--) {
+            node = node.getChild(string.charAt(i));
+            if (node == null) {
+                break;
+            } else if (node.value != null) {
+                res.add(new LookupResult<V>(i, node.value));
+            }
+        }
+        return res;
+    }
+}

--- a/src/main/resources/effective_tld_names.dat
+++ b/src/main/resources/effective_tld_names.dat
@@ -411,14 +411,19 @@ art.br
 ato.br
 b.br
 belem.br
+bhz.br
 bio.br
 blog.br
 bmd.br
+boavista.br
 bsb.br
+campinas.br
+caxias.br
 cim.br
 cng.br
 cnt.br
 com.br
+contagem.br
 coop.br
 cri.br
 cuiaba.br
@@ -432,15 +437,17 @@ esp.br
 etc.br
 eti.br
 far.br
+feira.br
 flog.br
 floripa.br
-fortal.br
 fm.br
 fnd.br
+fortal.br
 fot.br
 fst.br
 g12.br
 ggf.br
+goiania.br
 gov.br
 // gov.br 26 states + df https://en.wikipedia.org/wiki/States_of_Brazil
 ac.gov.br
@@ -474,7 +481,10 @@ gru.br
 imb.br
 ind.br
 inf.br
+jab.br
 jampa.br
+jdf.br
+joinville.br
 jor.br
 jus.br
 leg.br
@@ -485,6 +495,7 @@ maceio.br
 mat.br
 med.br
 mil.br
+morena.br
 mp.br
 mus.br
 natal.br
@@ -502,16 +513,24 @@ ppg.br
 pro.br
 psc.br
 psi.br
+pvh.br
 qsl.br
 radio.br
 rec.br
 recife.br
+ribeirao.br
+rio.br
 riobranco.br
+salvador.br
+sampa.br
 sjc.br
 slg.br
+slz.br
+sorocaba.br
 srv.br
 taxi.br
 teo.br
+the.br
 tmp.br
 trd.br
 tur.br
@@ -7501,9 +7520,6 @@ cheap
 // chintai : 2015-06-11 CHINTAI Corporation
 chintai
 
-// chloe : 2014-10-16 Richemont DNS Inc.
-chloe
-
 // christmas : 2013-11-21 Uniregistry, Corp.
 christmas
 
@@ -8374,9 +8390,6 @@ how
 // hsbc : 2014-10-24 HSBC Holdings PLC
 hsbc
 
-// htc : 2015-04-02 HTC corporation
-htc
-
 // hughes : 2015-07-30 Hughes Satellite Systems Corporation
 hughes
 
@@ -8830,12 +8843,6 @@ mattel
 // mba : 2015-04-02 Lone Hollow, LLC
 mba
 
-// mcd : 2015-07-30 McDonald’s Corporation
-mcd
-
-// mcdonalds : 2015-07-30 McDonald’s Corporation
-mcdonalds
-
 // mckinsey : 2015-07-31 McKinsey Holdings, Inc.
 mckinsey
 
@@ -8925,9 +8932,6 @@ money
 
 // monster : 2015-09-11 Monster Worldwide, Inc.
 monster
-
-// montblanc : 2014-06-23 Richemont DNS Inc.
-montblanc
 
 // mopar : 2015-07-30 FCA US LLC.
 mopar
@@ -9159,9 +9163,6 @@ ovh
 
 // page : 2014-12-04 Charleston Road Registry Inc.
 page
-
-// pamperedchef : 2015-02-05 The Pampered Chef, Ltd.
-pamperedchef
 
 // panasonic : 2015-07-30 Panasonic Corporation
 panasonic

--- a/src/test/java/crawlercommons/domains/EffectiveTldFinderPSLTest.java
+++ b/src/test/java/crawlercommons/domains/EffectiveTldFinderPSLTest.java
@@ -119,15 +119,14 @@ public class EffectiveTldFinderPSLTest {
         checkPublicSuffix("test.k12.ak.us", "test.k12.ak.us");
         checkPublicSuffix("www.test.k12.ak.us", "test.k12.ak.us");
         // IDN labels.
-        // TODO #179
-        // checkPublicSuffix("食狮.com.cn", "食狮.com.cn");
-        // checkPublicSuffix("食狮.公司.cn", "食狮.公司.cn");
-        // checkPublicSuffix("www.食狮.公司.cn", "食狮.公司.cn");
-        // checkPublicSuffix("shishi.公司.cn", "shishi.公司.cn");
-        // checkPublicSuffix("公司.cn", null);
-        // checkPublicSuffix("食狮.中国", "食狮.中国");
-        // checkPublicSuffix("www.食狮.中国", "食狮.中国");
-        // checkPublicSuffix("shishi.中国", "shishi.中国");
+        checkPublicSuffix("食狮.com.cn", "食狮.com.cn");
+        checkPublicSuffix("食狮.公司.cn", "食狮.公司.cn");
+        checkPublicSuffix("www.食狮.公司.cn", "食狮.公司.cn");
+        checkPublicSuffix("shishi.公司.cn", "shishi.公司.cn");
+        checkPublicSuffix("公司.cn", null);
+        checkPublicSuffix("食狮.中国", "食狮.中国");
+        checkPublicSuffix("www.食狮.中国", "食狮.中国");
+        checkPublicSuffix("shishi.中国", "shishi.中国");
         checkPublicSuffix("中国", null);
         // Same as above, but punycoded.
         checkPublicSuffix("xn--85x722f.com.cn", "xn--85x722f.com.cn");

--- a/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
+++ b/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
@@ -78,6 +78,12 @@ public class EffectiveTldFinderTest {
         assertEquals("co.uk", etld.getDomain());
         etld = EffectiveTldFinder.getEffectiveTLD("anything.uk");
         assertEquals("uk", etld.getDomain());
+        etld = EffectiveTldFinder.getEffectiveTLD("northleamingtonschool.warwickshire.sch.uk");
+        assertEquals("warwickshire.sch.uk", etld.getDomain());
+        assertFalse(etld.isWild());
+        etld = EffectiveTldFinder.getEffectiveTLD("sch.uk");
+        assertEquals("sch.uk", etld.getDomain());
+        assertTrue(etld.isWild());
     }
 
     @Test
@@ -104,6 +110,14 @@ public class EffectiveTldFinderTest {
         assertEquals("city.kawasaki.jp", etld.getDomain());
         assertEquals("city.kawasaki.jp", EffectiveTldFinder.getAssignedDomain("www.city.kawasaki.jp"));
         assertEquals(".kawasaki.jp", EffectiveTldFinder.getAssignedDomain(".kawasaki.jp"));
+        assertNull(EffectiveTldFinder.getAssignedDomain(".kawasaki.jp", true));
+        assertEquals("city.kawasaki.jp", EffectiveTldFinder.getAssignedDomain("city.kawasaki.jp", true));
+        // an wildcard eTLD itself is not a valid domain
+        assertNull(EffectiveTldFinder.getAssignedDomain("kawasaki.jp", true));
+        // and also items below (matching *.kawasaki.jp) are not valid domains
+        assertNull(EffectiveTldFinder.getAssignedDomain("nakahara.kawasaki.jp", true));
+        // valid domains are two levels below a wildcard eTLD
+        assertEquals("lions.nakahara.kawasaki.jp", EffectiveTldFinder.getAssignedDomain("lions.nakahara.kawasaki.jp", true));
     }
 
     @Test
@@ -171,14 +185,15 @@ public class EffectiveTldFinderTest {
     @Test
     public final void testIDNDomain() throws Exception {
         String ad = null;
-        ad = EffectiveTldFinder.getAssignedDomain("спб.бесплатныеобъявления.рф");
-        // assertEquals("бесплатныеобъявления.рф", ad); // TODO #179
-        ad = EffectiveTldFinder.getAssignedDomain("xn--90a1af.xn--80abbembcyvesfij3at4loa4ff.xn--p1ai");
+        ad = EffectiveTldFinder.getAssignedDomain("спб.бесплатныеобъявления.рф", true);
+        assertEquals("бесплатныеобъявления.рф", ad);
+        ad = EffectiveTldFinder.getAssignedDomain("xn--90a1af.xn--80abbembcyvesfij3at4loa4ff.xn--p1ai", true);
         assertEquals("xn--80abbembcyvesfij3at4loa4ff.xn--p1ai", ad);
         // rare but possible mixed use of UTF-8 and Punycode
-        ad = EffectiveTldFinder.getAssignedDomain("xn--90a1af.бесплатныеобъявления.рф");
-        // TODO #179
-        // assertEquals("xn--80abbembcyvesfij3at4loa4ff.xn--p1ai", ad);
+        ad = EffectiveTldFinder.getAssignedDomain("xn--90a1af.бесплатныеобъявления.рф", true);
+        assertEquals("бесплатныеобъявления.рф", ad);
+        ad = EffectiveTldFinder.getAssignedDomain("xn--90a1af.xn--80abbembcyvesfij3at4loa4ff.рф", true);
+        assertEquals("xn--80abbembcyvesfij3at4loa4ff.рф", ad);
     }
 
     @Test

--- a/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
+++ b/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
@@ -112,7 +112,7 @@ public class EffectiveTldFinderTest {
         assertEquals(".kawasaki.jp", EffectiveTldFinder.getAssignedDomain(".kawasaki.jp"));
         assertNull(EffectiveTldFinder.getAssignedDomain(".kawasaki.jp", true));
         assertEquals("city.kawasaki.jp", EffectiveTldFinder.getAssignedDomain("city.kawasaki.jp", true));
-        // an wildcard eTLD itself is not a valid domain
+        // a wildcard eTLD itself is not a valid domain
         assertNull(EffectiveTldFinder.getAssignedDomain("kawasaki.jp", true));
         // and also items below (matching *.kawasaki.jp) are not valid domains
         assertNull(EffectiveTldFinder.getAssignedDomain("nakahara.kawasaki.jp", true));
@@ -212,6 +212,13 @@ public class EffectiveTldFinderTest {
         assertEquals("myblog.blogspot.com", ad);
         ad = EffectiveTldFinder.getAssignedDomain("myblog.blogspot.com", true, true);
         assertEquals("blogspot.com", ad);
+    }
+
+    @Test
+    public final void testInvalidHostname() throws Exception {
+        // in strict mode: there should nothing be returned for invalid
+        // hostnames
+        assertNull(EffectiveTldFinder.getAssignedDomain("www..example..com", true, false));
     }
 
 }

--- a/src/test/java/crawlercommons/domains/SuffixTrieTest.java
+++ b/src/test/java/crawlercommons/domains/SuffixTrieTest.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2017 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.domains;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+
+public class SuffixTrieTest {
+
+    @Test
+    public final void testSuffixTrie() throws Exception {
+        SuffixTrie<Boolean> trie = new SuffixTrie<>();
+        String[] strings = { "www.example.com", "subdomain.example.com", "example.com", "co.uk", "com.ac", "com" };
+        for (String s : strings) {
+            assertFalse(trie.contains(s));
+            trie.put(s, true);
+            assertTrue(trie.contains(s));
+        }
+        for (String s : strings) {
+            assertTrue(trie.contains(s));
+        }
+        assertFalse(trie.contains(""));
+        assertEquals(4, trie.getLongestSuffix("www.subdomain.example.com").offset);
+        // insert empty string and test again
+        trie.put("", true);
+        assertTrue(trie.contains(""));
+        assertEquals(0, trie.getLongestSuffix("").offset);
+        // test whether all suffixes contained in string and trie are found
+        List<SuffixTrie.LookupResult<Boolean>> suffixes = trie.getSuffixes("www.subdomain.example.com");
+        assertEquals(4, suffixes.size());
+        assertEquals(25, suffixes.get(0).offset);
+        assertEquals(22, suffixes.get(1).offset);
+        assertEquals(14, suffixes.get(2).offset);
+        assertEquals(4, suffixes.get(3).offset);
+    }
+}


### PR DESCRIPTION
fixes #179
- allow eTLDs to appear as IDN variants
  * one or more dot-separated parts as IDN,
  * optionally others as punycoded IDNA
- speed-up lookup of public suffixes / eTLDs using a suffix trie
- update public suffix list to recent version
- add unit tests for wildcard eTLDs