### PR TITLE
Add SiteMapParser#walkSiteMap(URL,Consumer)

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -289,7 +289,8 @@ public class SiteMapParser {
      *             {@link java.net.URL}
      */
     public void walkSiteMap(URL onlineSitemapUrl, Consumer<SiteMapURL> action) throws UnknownFormatException, IOException {
-        if (action == null) {
+        if (onlineSitemapUrl == null || action == null) {
+            LOG.debug("Got null sitemap URL and/or action, stopping traversal");
             return;
         }
         walkSiteMap(parseSiteMap(onlineSitemapUrl), action);
@@ -318,6 +319,7 @@ public class SiteMapParser {
      */
     public void walkSiteMap(AbstractSiteMap sitemap, Consumer<SiteMapURL> action) throws UnknownFormatException, IOException {
         if (sitemap == null || action == null) {
+            LOG.debug("Got null sitemap and/or action, stopping traversal");
             return;
         }
         if (sitemap.isIndex()) {

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -268,14 +268,14 @@ public class SiteMapParser {
     }
 
     /**
-     * Fetch a sitemap from the specified URL, recursively traverse any
-     * enclosed sitemap index, and perform the specified action for each
-     * sitemap URL until all URLs have been processed or the action throws an
-     * exception.
-     *
+     * Fetch a sitemap from the specified URL, recursively fetching and
+     * traversing the content of any enclosed sitemap index, and performing the
+     * specified action for each sitemap URL until all URLs have been processed
+     * or the action throws an exception.
+     * <p>
      * This method is a convenience method for a user who has a sitemap URL and
-     * wants a "Keep it simple" way to traverse it.
-     *
+     * wants a simple way to traverse it.
+     * <p>
      * Exceptions thrown by the action are relayed to the caller.
      *
      * @param onlineSitemapUrl
@@ -292,8 +292,32 @@ public class SiteMapParser {
         if (action == null) {
             return;
         }
-        AbstractSiteMap sitemap = parseSiteMap(onlineSitemapUrl);
-        if (sitemap == null) {
+        walkSiteMap(parseSiteMap(onlineSitemapUrl), action);
+    }
+
+    /**
+     * Traverse a sitemap, recursively fetching and traversing the content of
+     * any enclosed sitemap index, and performing the specified action for each
+     * sitemap URL until all URLs have been processed or the action throws an
+     * exception.
+     * <p>
+     * This method is a convenience method for a user who has a sitemap and
+     * wants a simple way to traverse it.
+     * <p>
+     * Exceptions thrown by the action are relayed to the caller.
+     *
+     * @param sitemap
+     *            The sitemap to traverse
+     * @param action
+     *            The action to be performed for each element
+     * @throws UnknownFormatException
+     *             if there is an error parsing the sitemap
+     * @throws IOException
+     *             if there is an error fetching the content of any
+     *             {@link java.net.URL}
+     */
+    public void walkSiteMap(AbstractSiteMap sitemap, Consumer<SiteMapURL> action) throws UnknownFormatException, IOException {
+        if (sitemap == null || action == null) {
             return;
         }
         if (sitemap.isIndex()) {

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -306,7 +306,6 @@ public class SiteMapParser {
             }
         } else {
             final Collection<SiteMapURL> links = ((SiteMap) sitemap).getSiteMapUrls();
-            links.forEach(action);
             for (final SiteMapURL url : links) {
                 if (url == null) {
                     continue;

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -31,8 +31,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.text.SimpleDateFormat;
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Locale;
 
 import org.apache.commons.io.IOUtils;
@@ -499,6 +501,20 @@ public class SiteMapParserTest {
 
         SiteMapIndex smi = (SiteMapIndex) asm;
         assertEquals(1, smi.getSitemaps().size());
+    }
+
+    @Test
+    public void testWalkSiteMap() throws UnknownFormatException, IOException {
+        SiteMapParser parser = new SiteMapParser();
+        String contentType = "text/xml";
+        byte[] content = getXMLSitemapAsBytes();
+        URL url = new URL("http://www.example.com/sitemap.xml");
+
+        AbstractSiteMap asm = parser.parseSiteMap(contentType, content, url);
+        final List<SiteMapURL> urls = new ArrayList<>();
+
+        parser.walkSiteMap(asm, urls::add);
+        assertEquals(sitemapURLs.length, urls.size());
     }
 
     /**


### PR DESCRIPTION
This PR adds a convenience method to fetch a sitemap from the specified URL, recursively traverse any enclosed sitemap index, and perform the specified action for each sitemap URL. It is strongly inspired by methods like [`Iterable#forEach`](https://docs.oracle.com/javase/8/docs/api/java/lang/Iterable.html#forEach-java.util.function.Consumer-) and [`Stream#forEach`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#forEach-java.util.function.Consumer-).

The code is based on [SitemapParser.java](https://github.com/Chaiavi/SitemapParser/blob/master/src/main/java/org/chaiware/SitemapParser.java) by @chaiavi, with extra checks to avoid NullPointerExceptions.

I added the method to `SiteMapParser` rather than `AbstractSiteMap` since the parser is needed to recurse into sitemap indices.

I'm open to suggestions regarding the method's name and null-friendliness.