### PR TITLE
Add main to SimpleRobotRulesParser for testing

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -109,4 +109,29 @@ public abstract class BaseRobotRules implements Serializable {
         return true;
     }
 
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(getClass()).append(":\n");
+        long delay = getCrawlDelay();
+        if (delay == UNSET_CRAWL_DELAY) {
+            sb.append(" - no crawl delay\n");
+        } else {
+            sb.append(" - crawl delay: ").append(delay).append('\n');
+        }
+        int nSitemaps = getSitemaps().size();
+        if (nSitemaps == 0) {
+            sb.append(" - no sitemap URLs\n");
+        } else {
+            sb.append(" - number of sitemap URLs: ").append(nSitemaps).append('\n');
+            sb.append("   sitemaps[0]: ").append(getSitemaps().get(0)).append('\n');
+        }
+        return sb.toString();
+    }
+
 }

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -254,8 +254,7 @@ public class SimpleRobotRules extends BaseRobotRules {
                 }
             } else {
                 // See if the pattern from patternPos to wildcardPos matches the
-                // text
-                // starting at textPos
+                // text starting at textPos
                 while ((patternPos < wildcardPos) && (textPos < textEnd)) {
                     if (text.charAt(textPos++) != pattern.charAt(patternPos++)) {
                         return false;
@@ -265,17 +264,14 @@ public class SimpleRobotRules extends BaseRobotRules {
         }
 
         // If we didn't reach the end of the pattern, make sure we're not at a
-        // wildcard, sa
-        // that's a 0 or more match, so then we're still OK.
+        // wildcard, that's a 0 or more match, so then we're still OK.
         while ((patternPos < patternEnd) && (pattern.charAt(patternPos) == '*')) {
             patternPos += 1;
         }
 
         // We're at the end, so we have a match if the pattern was completely
-        // consumed,
-        // and either we consumed all the text or we didn't have to match it all
-        // (no '$' at end
-        // of the pattern)
+        // consumed, and either we consumed all the text or we didn't have to
+        // match it all (no '$' at end of the pattern)
         return (patternPos == patternEnd) && ((textPos == textEnd) || !containsEndChar);
     }
 
@@ -343,6 +339,36 @@ public class SimpleRobotRules extends BaseRobotRules {
         } else if (!_rules.equals(other._rules))
             return false;
         return true;
+    }
+
+    /*
+     * (non-Javadoc)
+     * 
+     * @see java.lang.Object#equals(java.lang.Object)
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(super.toString());
+        int nRules = _rules.size();
+        if (nRules == 0) {
+            sb.append(" - no rules");
+            if (isAllowNone()) {
+                sb.append(" (allow none)");
+            } else if (isAllowAll()) {
+                sb.append(" (allow all)");
+            }
+            sb.append('\n');
+        } else {
+            sb.append(" - number of rules: ").append(nRules).append('\n');
+            if (nRules <= 10) {
+                for (int i = 0; i < nRules; i++) {
+                    RobotRule r = _rules.get(i);
+                    sb.append(r._allow ? "   A" : "   Disa").append("llow: ").append(r._prefix).append('\n');
+                }
+            }
+        }
+        return sb.toString();
     }
 
 }

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -32,7 +32,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.tika.Tika;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -819,8 +818,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                 // sitemap paths for file:/ URLs
                 url = "http://example.com/robots.txt";
             }
-            String contentType = new Tika().detect(content, url);
-            rules = parser.parseContent(url, content, contentType, agentName);
+            rules = parser.parseContent(url, content, "text/plain", agentName);
         } catch (IOException e) {
             if (connection instanceof HttpURLConnection) {
                 int code = ((HttpURLConnection) connection).getResponseCode();


### PR DESCRIPTION
for quick testing whether a robots.txt is parsed as expected, e.g.
```
$ java ... SimpleRobotRulesParser http://www.robotstxt.org/robots.txt '*' http://www.robotstxt.org/norobots-rfc.txt
Checking URLs:
allowed         http://www.robotstxt.org/norobots-rfc.txt
```

The full set of options is:
```
SimpleRobotRulesParser <robots.txt> [[<agentname>] <URL>...]

Parse a robots.txt file
  <robots.txt>  URL pointing to robots.txt file.
                To read a local file use a file:// URL
                (parsed as http://example.com/robots.txt)
  <agentname>   user agent name to check for exclusion rules.
                If not defined check with '*'
  <URL>         check URL whether allowed or forbidden.
                If no URL is given show robots.txt rules
```

The pull request includes also the following minor changes:
- implement `toString()` for robot rules
- fix line breaks in comments