### PR TITLE
Improve sitemap parsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,10 @@
 Crawler-Commons Change Log
 
 Current Development 0.10-SNAPSHOT (yyyy-mm-dd)
+- Sitemap file location to ignore query part of URL (sebastian-nagel) #202
+- [RSS sitemaps] Link extraction from RSS feeds fails on XML entities (sebastian-nagel) #204
+- [RSS sitemaps] Resolve relative links in RSS feeds (sebastian-nagel) #203
+- [RSS sitemaps] Extract links from <guid> elements (sebastian-nagel) #201
 - [Sitemaps] Limit on "bad url" log messages (sebastian-nagel) #145
 - EffectiveTldFinder to parse Internationalized Domain Names (sebastian-nagel) #179
 - Add main() to EffectiveTldFinder (sebastian-nagel) #187

--- a/src/main/java/crawlercommons/sitemaps/SiteMap.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMap.java
@@ -108,9 +108,26 @@ public class SiteMap extends AbstractSiteMap {
      * @param sitemapUrl
      */
     private void setBaseUrl(URL sitemapUrl) {
-        // Remove everything back to last slash.
-        // So http://foo.org/abc/sitemap.xml becomes http://foo.org/abc/
-        baseUrl = sitemapUrl.toString().replaceFirst("/[^/]*$", "/");
+        // Remove everything back to last slash on the file path:
+        // - http://example.com/abc/sitemap.xml
+        // becomes
+        // - http://example.com/abc/
+        // But ignore slashes in the query part:
+        // - http://example.com/index.php?route=feed/imagemap
+        // becomes
+        // - http://example.com/
+        String path = sitemapUrl.getPath();
+        int lastPathDelimPos = path.lastIndexOf('/');
+        if (lastPathDelimPos < 0) {
+            path = "/";
+        } else {
+            path = path.substring(0, lastPathDelimPos + 1);
+        }
+        try {
+            baseUrl = new URL(sitemapUrl.getProtocol(), sitemapUrl.getHost(), sitemapUrl.getPort(), path).toString();
+        } catch (MalformedURLException e) {
+            baseUrl = sitemapUrl.toString();
+        }
     }
 
     /**

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -443,14 +443,6 @@ public class SiteMapParser {
      * @return true if testUrl is under sitemapBaseUrl, false otherwise
      */
     public static boolean urlIsValid(String sitemapBaseUrl, String testUrl) {
-        boolean ret = false;
-
-        // Don't try a comparison if the URL is too short to match
-        if (sitemapBaseUrl != null && sitemapBaseUrl.length() <= testUrl.length()) {
-            String u = testUrl.substring(0, sitemapBaseUrl.length());
-            ret = sitemapBaseUrl.equals(u);
-        }
-
-        return ret;
+        return testUrl.startsWith(sitemapBaseUrl);
     }
 }

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -102,10 +102,8 @@ public class DelegatorHandler extends DefaultHandler {
             delegate = new AtomHandler(url, elementStack, strict);
         }
         // See if it is a RSS feed by looking for the localName "channel"
-        // element .
-        // This avoids the issue
-        // of having the outer tag named <rdf:RDF> that was causing this code to
-        // fail. Inside of
+        // element. This avoids the issue of having the outer tag named
+        // <rdf:RDF> that was causing this code to fail. Inside of
         // the <rss> or <rdf> tag is a <channel> tag, so we can use that.
         // See https://github.com/crawler-commons/crawler-commons/issues/87
         // and also RSS 1.0 specification http://web.resource.org/rss/1.0/spec

--- a/src/test/resources/rss/feed.rss
+++ b/src/test/resources/rss/feed.rss
@@ -1,0 +1,37 @@
+
+<!-- extended from https://en.wikipedia.org/wiki/RSS#Example -->
+
+<rss version="2.0">
+<channel>
+ <title>RSS Title</title>
+ <description>This is an example of an RSS feed</description>
+ <link>https://www.example.com/main.html</link>
+ <lastBuildDate>Mon, 06 Sep 2010 00:01:00 +0000 </lastBuildDate>
+ <pubDate>Sun, 06 Sep 2009 16:20:00 +0000</pubDate>
+ <ttl>1800</ttl>
+
+ <item>
+  <title>Example entry</title>
+  <description>Here is some text containing an interesting description.</description>
+  <link>https://www.example.com/blog/post/1</link>
+  <guid isPermaLink="false">7bd204c6-1655-4c27-aeee-53f933c5395f</guid>
+  <pubDate>Sun, 06 Sep 2009 16:20:00 +0000</pubDate>
+ </item>
+
+ <item>
+  <title>&amp;guid&amp; element instead of &amp;link&amp;</title>
+  <guid isPermaLink="false">https://www.example.com/guid.html</guid>
+ </item>
+
+ <item>
+  <title>XML entity in link content</title>
+  <link>https://www.example.com/foo?q=a&amp;l=en</link>
+ </item>
+
+ <item>
+  <title>CDATA</title>
+  <link>https://www.example.com/foo<![CDATA[?q=a&l=fr]]></link>
+ </item>
+
+</channel>
+</rss>


### PR DESCRIPTION
- ignore query part of URL to determine sitemap location prefix for URL validation, fixes #202
- resolve relative links in RSS feeds, fixes #203
- allow non-continuous content (containing XML entities or CDATA) when parsing links in RSS feeds, fixes #204
- extract links from <guid> elements in RSS feeds, fixes #201 

Note: this PR includes and is based on PR #200 