### PR TITLE
Sitemaps limit on "bad url" log messages, fixes #145

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.10-SNAPSHOT (yyyy-mm-dd)
+- [Sitemaps] Limit on "bad url" log messages (sebastian-nagel) #145
 - EffectiveTldFinder to parse Internationalized Domain Names (sebastian-nagel) #179
 - Add main() to EffectiveTldFinder (sebastian-nagel) #187
 - Handle new suffixes in PaidLevelDomain (kkrugler) #183

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -301,8 +301,9 @@ public class SiteMapParser {
         int i = 0;
         while ((line = reader.readLine()) != null && ++i <= MAX_URLS) {
             line = line.trim();
-            if (line.isEmpty())
+            if (line.isEmpty()) {
                 continue;
+            }
             try {
                 URL url = new URL(line);
                 boolean valid = urlIsValid(textSiteMap.getBaseUrl(), url.toString());


### PR DESCRIPTION
- degrade log level from warn to debug for lines which are not valid URLs (same level as for all XML-based sitemap formats)
- only log first 1024 characters of line

Improvements:
- inline addUrlIntoSitemap(...)
- trim lines / URLs