### PR TITLE
Add JAX-B dependencies to POM

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.10-SNAPSHOT (yyyy-mm-dd)
+- Add JAX-B dependencies to POM (jnioche) #207
 - Add method to parse and iterate sitemap SiteMapParser#walkSiteMap(URL,Consumer) (Luc Boruta) #190
 - Sitemap file location to ignore query part of URL (sebastian-nagel) #202
 - [RSS sitemaps] Link extraction from RSS feeds fails on XML entities (sebastian-nagel) #204

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,7 @@
 		<mockito-core.version>1.8.0</mockito-core.version>
 		<jetty.version>5.1.10</jetty.version>
 		<servlet-api.version>2.5</servlet-api.version>
+		<jaxb-api.version>2.2.11</jaxb-api.version>
 
 		<!-- Maven Plugin Dependencies -->
 		<maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
@@ -361,6 +362,13 @@
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
 			<version>${slf4j-api.version}</version>
+		</dependency>
+
+        <!-- see https://github.com/crawler-commons/crawler-commons/issues/196 -->
+		<dependency>
+			<groupId>javax.xml.bind</groupId>
+			<artifactId>jaxb-api</artifactId>
+			<version>${jaxb-api.version}</version>
 		</dependency>
 
 		<!-- Test dependencies -->


### PR DESCRIPTION
see #196 
java.time.format.DateFormatter.ISO_OFFSET_DATE_TIME can't be used as a straightforward replacement  so instead I opted to add the dependency 