### PR TITLE
Make RobotRules accessible #134

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Current Development 0.10-SNAPSHOT (yyyy-mm-dd)
 - Handle new suffixes in PaidLevelDomain (kkrugler) #183
 - Remove Tika dependency (kkrugler) #199
 - Improve MIME detection for sitemaps (sebastian-nagel) #200
+- Make RobotRules accessible #134
 
 Release 0.9 (2017-10-27)
 - [Sitemaps] Removed DOM-based sitemap parser (jnioche) #177

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -21,6 +21,7 @@ import java.net.URL;
 import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 /**
  * Result from parsing a single robots.txt file - which means we get a set of
@@ -38,12 +39,21 @@ public class SimpleRobotRules extends BaseRobotRules {
      * Single rule that maps from a path prefix to an allow flag.
      */
     public static class RobotRule implements Comparable<RobotRule>, Serializable {
+
         String _prefix;
         boolean _allow;
 
         public RobotRule(String prefix, boolean allow) {
             _prefix = prefix;
             _allow = allow;
+        }
+
+        public boolean isAllow() {
+            return this._allow;
+        }
+
+        public String getPrefix() {
+            return this._prefix;
         }
 
         // Sort from longest to shortest rules.
@@ -103,8 +113,8 @@ public class SimpleRobotRules extends BaseRobotRules {
 
     }
 
-    private ArrayList<RobotRule> _rules;
-    private RobotRulesMode _mode;
+    protected ArrayList<RobotRule> _rules;
+    protected RobotRulesMode _mode;
 
     public SimpleRobotRules() {
         this(RobotRulesMode.ALLOW_SOME);
@@ -129,6 +139,10 @@ public class SimpleRobotRules extends BaseRobotRules {
         }
 
         _rules.add(new RobotRule(prefix, allow));
+    }
+
+    public List<RobotRule> getRobotRules() {
+        return this._rules;
     }
 
     public boolean isAllowed(String url) {

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -351,7 +351,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     private int _numWarnings;
 
     @Override
-    public BaseRobotRules failedFetch(int httpStatusCode) {
+    public SimpleRobotRules failedFetch(int httpStatusCode) {
         SimpleRobotRules result;
 
         if ((httpStatusCode >= 200) && (httpStatusCode < 300)) {
@@ -386,7 +386,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * byte[], java.lang.String, java.lang.String)
      */
     @Override
-    public BaseRobotRules parseContent(String url, byte[] content, String contentType, String robotNames) {
+    public SimpleRobotRules parseContent(String url, byte[] content, String contentType, String robotNames) {
         _numWarnings = 0;
 
         // If there's nothing there, treat it like we have no restrictions.


### PR DESCRIPTION
- Makes SimpleRobotRulesParser._rules property protected
  and adds getters for SimpleRobotRulesParser._rules and
  RobotRules's properties
- Changes SimpleRobotRulesParser return type from BaseRobotRules
  to SimpleRobotRules to allow access to concrete class without
  nasty type casts while still obeying super class contract