### PR TITLE
Allow for legacy URIs when checking sitemap namespaces

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/Namespace.java
+++ b/src/main/java/crawlercommons/sitemaps/Namespace.java
@@ -16,6 +16,10 @@
 
 package crawlercommons.sitemaps;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * supported sitemap formats:
  * https://www.sitemaps.org/protocol.html#otherformats
@@ -23,6 +27,50 @@ package crawlercommons.sitemaps;
 public class Namespace {
 
     public static final String SITEMAP = "http://www.sitemaps.org/schemas/sitemap/0.9";
+
+    /**
+     * Legacy schema URIs from prior sitemap protocol versions and frequent
+     * variants.
+     */
+    public static final String[] SITEMAP_LEGACY = { //
+                    "https://www.sitemaps.org/schemas/sitemap/0.9", //
+                    "http://www.sitemaps.org/schemas/sitemap/0.9/", //
+                    "https://www.sitemaps.org/schemas/sitemap/0.9/", //
+                    "http://www.google.com/schemas/sitemap/0.9", //
+                    "https://www.google.com/schemas/sitemap/0.9", //
+                    "http://www.google.com/schemas/sitemap/0.84", //
+                    "https://www.google.com/schemas/sitemap/0.84", //
+                    "http://www.google.com/schemas/sitemap/0.90", //
+                    "https://sitemaps.org/schemas/sitemap/0.9",
+                    };
+
+    public static final String[] IMAGE = { //
+                    "http://www.google.com/schemas/sitemap-image/1.1", //
+                    "https://www.google.com/schemas/sitemap-image/1.1" //
+                    };
+
+    public static final String[] VIDEO = { //
+                    "http://www.google.com/schemas/sitemap-video/1.1", //
+                    "https://www.google.com/schemas/sitemap-video/1.1" //
+    };
+
+    public static final String[] NEWS = { //
+                    "http://www.google.com/schemas/sitemap-news/0.9", //
+                    "https://www.google.com/schemas/sitemap-news/0.9", //
+                    "http://www.google.com/schemas/sitemap-news/0.84" //
+    };
+
+    public static final String LINKS = "http://www.w3.org/1999/xhtml";
+
+    /**
+     * In contradiction to the protocol specification ("The Sitemap must ...
+     * [s]pecify the namespace (protocol standard) within the &lt;urlset&gt;
+     * tag."), some sitemaps do not define a (default) namespace.
+     * 
+     * By accepting the "empty" namespace, you'll get URLs even from those
+     * sitemaps.
+     */
+    public static final String EMPTY = "";
 
     /**
      * RSS and Atom sitemap formats do not have strict definition. But if we do
@@ -34,5 +82,25 @@ public class Namespace {
     public static final String RSS_2_0 = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
     public static final String ATOM_0_3 = "http://purl.org/atom/ns#";
     public static final String ATOM_1_0 = "http://www.w3.org/2005/Atom";
+
+    public static final Set<String> SITEMAP_SUPPORTED_NAMESPACES = new HashSet<>();
+    static {
+        SITEMAP_SUPPORTED_NAMESPACES.add(SITEMAP);
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(SITEMAP_LEGACY));
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(IMAGE));
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(VIDEO));
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(NEWS));
+        SITEMAP_SUPPORTED_NAMESPACES.add(LINKS);
+    }
+
+    /**
+     * @param uri
+     *            URI string identifying the namespace
+     * @return true if namespace (identified by URI) is supported, false if the
+     *         namespace is not supported or unknown
+     */
+    public static boolean isSupported(String uri) {
+        return SITEMAP_SUPPORTED_NAMESPACES.contains(uri);
+    }
 
 }

--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -120,8 +120,11 @@ public class SiteMapParser {
 
     /**
      * Sets the parser to allow any namespace or just the one from the
-     * specification (or any namespace accepted,
-     * {@link #addAcceptedNamespace(String)})
+     * specification, or any accepted namespace (see
+     * {@link #addAcceptedNamespace(String)}). Note enabling strict namespace
+     * checking always adds the namespace defined by the current sitemap
+     * specificiation ({@link Namespace#SITEMAP}) to the list of accepted
+     * namespaces.
      */
     public void setStrictNamespace(boolean s) {
         strictNamespace = s;

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -112,9 +112,7 @@ public class DelegatorHandler extends DefaultHandler {
         // the <rss> or <rdf> tag is a <channel> tag, so we can use that.
         // See https://github.com/crawler-commons/crawler-commons/issues/87
         // and also RSS 1.0 specification http://web.resource.org/rss/1.0/spec
-        else if ("rss".equals(localName)) {
-            return; // ignore
-        } else if ("channel".equals(localName)) {
+        else if ("channel".equals(localName)) {
             delegate = new RSSHandler(url, elementStack, strict);
         } else if ("sitemapindex".equals(localName)) {
             delegate = new XMLIndexHandler(url, elementStack, strict);

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -16,8 +16,12 @@
 
 package crawlercommons.sitemaps.sax;
 
+import static crawlercommons.sitemaps.SiteMapParser.LOG;
+
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.LinkedList;
+import java.util.Set;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -40,6 +44,7 @@ public class DelegatorHandler extends DefaultHandler {
     private boolean strict;
     private boolean strictNamespace;
     private UnknownFormatException exception;
+    private Set<String> acceptedNamespaces;
 
     protected DelegatorHandler(LinkedList<String> elementStack, boolean strict) {
         this.elementStack = elementStack;
@@ -60,20 +65,20 @@ public class DelegatorHandler extends DefaultHandler {
         return strict;
     }
 
-    /**
-     * @return whether the parser allows any namespace or just the one from the
-     *         specification
-     */
-    public boolean isStrictNamespace() {
+    protected boolean isStrictNamespace() {
         return strictNamespace;
     }
 
-    /**
-     * Sets the parser to allow any namespace or just the one from the
-     * specification
-     */
     public void setStrictNamespace(boolean s) {
         strictNamespace = s;
+    }
+
+    public void setAcceptedNamespaces(Set<String> acceptedSet) {
+        acceptedNamespaces = acceptedSet;
+    }
+
+    protected boolean isAcceptedNamespace(String uri) {
+        return acceptedNamespaces.contains(uri);
     }
 
     protected void setException(UnknownFormatException exception) {
@@ -107,19 +112,48 @@ public class DelegatorHandler extends DefaultHandler {
         // the <rss> or <rdf> tag is a <channel> tag, so we can use that.
         // See https://github.com/crawler-commons/crawler-commons/issues/87
         // and also RSS 1.0 specification http://web.resource.org/rss/1.0/spec
-        else if ("channel".equals(localName)) {
+        else if ("rss".equals(localName)) {
+            return; // ignore
+        } else if ("channel".equals(localName)) {
             delegate = new RSSHandler(url, elementStack, strict);
-        } else if (isStrictNamespace() && !Namespace.SITEMAP.equals(uri)) {
-            setException(new UnknownFormatException("Namespace " + uri + " does not match standard namespace " + Namespace.SITEMAP));
-            return;
         } else if ("sitemapindex".equals(localName)) {
             delegate = new XMLIndexHandler(url, elementStack, strict);
         } else if ("urlset".equals(localName)) {
             delegate = new XMLHandler(url, elementStack, strict);
+        } else {
+            LOG.debug("Skipped unknown root element <{}> in {}", localName, url);
+            return;
         }
-        if (delegate != null) {
-            // configure delegate
-            delegate.setStrictNamespace(isStrictNamespace());
+        // configure delegate
+        delegate.setStrictNamespace(isStrictNamespace());
+        delegate.setAcceptedNamespaces(acceptedNamespaces);
+        // validate XML namespace
+        if (isStrictNamespace()) {
+            if (delegate instanceof AtomHandler || delegate instanceof RSSHandler) {
+                // no namespace checking for feeds
+                return;
+            }
+            if (!isAcceptedNamespace(uri) && uri.startsWith("/")) {
+                // first, try to resolve relative namespace URI (deprecated but
+                // not forbidden), e.g., //www.sitemaps.org/schemas/sitemap/0.9
+                try {
+                    URL u = new URL(url, uri);
+                    uri = u.toString();
+                } catch (MalformedURLException e) {
+                    LOG.warn("Failed to resolve relative namespace URI {} in sitemap {}", uri, url);
+                }
+            }
+            if (!isAcceptedNamespace(uri)) {
+                String msg;
+                if (!Namespace.isSupported(uri)) {
+                    msg = "Unsupported namespace <" + uri + ">";
+                } else {
+                    msg = "Namespace <" + uri + "> not accepted";
+                }
+                setException(new UnknownFormatException(msg));
+                delegate = null;
+                return;
+            }
         }
     }
 

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -29,7 +29,6 @@ import org.xml.sax.SAXParseException;
 
 import crawlercommons.sitemaps.AbstractSiteMap;
 import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
-import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
 import crawlercommons.sitemaps.SiteMapURL;
 
@@ -72,7 +71,8 @@ class XMLHandler extends DelegatorHandler {
     }
 
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
-        if (isStrictNamespace() && !Namespace.SITEMAP.equals(uri)) {
+        if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
+            LOG.debug("Skip element <{}>, namespace <{}> not accepted", localName, uri);
             currentElementNamespaceIsValid = false;
             return;
         }
@@ -98,7 +98,7 @@ class XMLHandler extends DelegatorHandler {
     }
 
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if (isStrictNamespace() && !Namespace.SITEMAP.equals(uri)) {
+        if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
             return;
         }
         if ("url".equals(localName) && "urlset".equals(currentElementParent())) {

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
@@ -28,7 +28,6 @@ import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
 import crawlercommons.sitemaps.AbstractSiteMap;
-import crawlercommons.sitemaps.Namespace;
 import crawlercommons.sitemaps.SiteMap;
 import crawlercommons.sitemaps.SiteMapIndex;
 import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
@@ -71,7 +70,7 @@ class XMLIndexHandler extends DelegatorHandler {
     }
 
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if (isStrictNamespace() && !Namespace.SITEMAP.equals(uri)) {
+        if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
             return;
         }
         if ("sitemap".equals(currentElement())) {

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -145,7 +145,7 @@ public class SiteMapParserTest {
             asm = parser.parseSiteMap(content, url);
             fail("Expected an UnknownFormatException because of wrong namespace");
         } catch (UnknownFormatException e) {
-            assertTrue(e.getMessage().contains("does not match standard namespace"));
+            assertTrue(e.getMessage().matches("Namespace .* not accepted"));
         }
 
         // try again in lenient mode


### PR DESCRIPTION
- e.g., allow legacy namespace URI but ignore URLs
  from image and video sitemap extensions
- resolve relative namespace URIs
- add namespace URIs of sitemap extensions (news, images, videos)

E.g., to check the namespace but allow legacy URIs and also sitemaps without a namespace declaration:
```
sitemapParser.setStrictNamespace(true);
sitemapParser.addAcceptedNamespace(Namespace.SITEMAP_LEGACY);
sitemapParser.addAcceptedNamespace(Namespace.EMPTY);
```

To allow image URLs one could add
```
sitemapParser.addAcceptedNamespace(Namespace.IMAGE);
```
It's also easy to add any other namespace URI.