### PR TITLE
EffectiveTldFinder throws IllegalArgumentException on IDN domain names containing prohibited characters, fixes #231

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 0.11-SNAPSHOT (yyyy-mm-dd)
+- EffectiveTldFinder throws IllegalArgumentException on IDN domain names containing prohibited characters (sebastian-nagel) #231
 - [Sitemaps] Sitemap index: stop URL at closing </loc> (sebastian-nagel, kkrugler) #213
 - [Sitemaps] Allow empty price in video sitemaps (sebastian-nagel) #221
 - [Sitemaps] In case of the use of a different locale, price tag can be formatted with ',' instead of '.' leading to a NPE (goldenlink) #220

--- a/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
+++ b/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
@@ -219,6 +219,20 @@ public class EffectiveTldFinderTest {
         // in strict mode: there should nothing be returned for invalid
         // hostnames
         assertNull(EffectiveTldFinder.getAssignedDomain("www..example..com", true, false));
+        // prohibited Unicode characters in internationalized domain name (IDN),
+        // test for #231): � (U+FFFD REPLACEMENT CHARACTER) is prohibited by
+        // RFC3490
+        // (1) in public suffix
+        assertNull(EffectiveTldFinder.getAssignedDomain("www.example.c\ufffdm", true, false));
+        // (1a) in wildcard part of a public suffix
+        assertNull(EffectiveTldFinder.getAssignedDomain("\ufffd.kawasaki.jp", true, false));
+        // (2) in dot-separated segment immediately before public suffix
+        // => fail / null : there is no valid domain name
+        assertNull(EffectiveTldFinder.getAssignedDomain("www.ex\ufffdmple.com", true, false));
+        // (3) in dot-separated segment not part of the domain name
+        // => "example.com" is a valid domain name, no check whether the input
+        // host name is valid
+        assertEquals("example.com", EffectiveTldFinder.getAssignedDomain("\ufffd.example.com", true, false));
     }
 
 }


### PR DESCRIPTION
- catch IllegalArgumentException when converting IDNs to ASCII
- validate domain names returned by getAssignedDomain(...)
- add unit tests, complete Javadoc

The behavior of `EffectiveTldFinder.getAssignedDomain(hostname)` in case there are prohibited characters is now (see updated unit test):
1. in the public suffix ("effective TLD") or the domain name: return null or hostname depending on the `strict` flag
2. as part of the hostname but not the domain name part: return the valid domain name

