### PR TITLE
Buffer characters when characters(...) is called, fixes #225 and #226

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,8 @@
 Crawler-Commons Change Log
 
 Current Development 0.11-SNAPSHOT (yyyy-mm-dd)
+- [Sitemaps] XMLHandler needs to append text in characters() vs. immediately processing (kkrugler, sebastian-nagel) #226
+- [Sitemaps] XMLIndexHandler needs to accumulate the lastmod date string before parsing (kkrugler, sebastian-nagel) #225
 - EffectiveTldFinder throws IllegalArgumentException on IDN domain names containing prohibited characters (sebastian-nagel) #231
 - [Sitemaps] Trim Unicode whitespace around URLs (sebastian-nagel, kkrugler) #224
 - [Sitemaps] Sitemap index: stop URL at closing </loc> (sebastian-nagel, kkrugler) #213

--- a/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
@@ -110,9 +110,9 @@ class AtomHandler extends DelegatorHandler {
 
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if ("entry".equals(currentElement())) {
+        if ("entry".equals(localName)) {
             maybeAddSiteMapUrl();
-        } else if ("feed".equals(currentElement())) {
+        } else if ("feed".equals(localName)) {
             sitemap.setProcessed(true);
         } else if ("updated".equals(localName)) {
             lastMod = getAndResetCharacterBuffer();

--- a/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
@@ -77,6 +77,7 @@ class AtomHandler extends DelegatorHandler {
         sitemap.setType(SitemapType.ATOM);
     }
 
+    @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         if ("entry".equals(localName)) {
             loc = null;
@@ -107,22 +108,25 @@ class AtomHandler extends DelegatorHandler {
         }
     }
 
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if ("entry".equals(currentElement())) {
             maybeAddSiteMapUrl();
         } else if ("feed".equals(currentElement())) {
             sitemap.setProcessed(true);
+        } else if ("updated".equals(localName)) {
+            lastMod = getAndResetCharacterBuffer();
         }
     }
 
+    @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
-        String localName = super.currentElement();
-        String value = String.valueOf(ch, start, length);
-        if ("updated".equals(localName)) {
-            lastMod = value;
+        if ("updated".equals(currentElement())) {
+            appendCharacterBuffer(ch, start, length);
         }
     }
 
+    @Override
     public AbstractSiteMap getSiteMap() {
         return sitemap;
     }
@@ -142,10 +146,12 @@ class AtomHandler extends DelegatorHandler {
         lastMod = null;
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -48,6 +48,7 @@ public class DelegatorHandler extends DefaultHandler {
     private UnknownFormatException exception;
     private Set<String> acceptedNamespaces;
     protected Map<String, Extension> extensionNamespaces;
+    protected StringBuilder characterBuffer = new StringBuilder();
 
     protected DelegatorHandler(LinkedList<String> elementStack, boolean strict) {
         this.elementStack = elementStack;
@@ -103,6 +104,7 @@ public class DelegatorHandler extends DefaultHandler {
         return exception;
     }
 
+    @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         if (elementStack.isEmpty() || delegate == null) {
             startRootElement(uri, localName, qName, attributes);
@@ -170,6 +172,7 @@ public class DelegatorHandler extends DefaultHandler {
         delegate.setExtensionNamespaces(extensionNamespaces);
     }
 
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if (delegate != null) {
             delegate.endElement(uri, localName, qName);
@@ -177,10 +180,36 @@ public class DelegatorHandler extends DefaultHandler {
         elementStack.pop();
     }
 
+    @Override
     public void characters(char ch[], int start, int length) throws SAXException {
         if (delegate != null) {
             delegate.characters(ch, start, length);
         }
+    }
+
+    protected void appendCharacterBuffer(char ch[], int start, int length) {
+        if (characterBuffer != null) {
+            for (int i = start; i < start + length; i++) {
+                characterBuffer.append(ch[i]);
+            }
+        }
+    }
+
+    protected void appendCharacterBuffer(String str) {
+        characterBuffer.append(str);
+    }
+
+    protected String getAndResetCharacterBuffer() {
+        if (characterBuffer == null) {
+            return null;
+        }
+        String value = characterBuffer.toString();
+        resetCharacterBuffer();
+        return value;
+    }
+
+    protected void resetCharacterBuffer() {
+        characterBuffer = new StringBuilder();
     }
 
     protected String currentElement() {
@@ -197,12 +226,14 @@ public class DelegatorHandler extends DefaultHandler {
         return delegate.getSiteMap();
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         if (delegate != null) {
             delegate.error(e);
         }
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         if (delegate != null) {
             delegate.fatalError(e);

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -48,7 +48,7 @@ public class DelegatorHandler extends DefaultHandler {
     private UnknownFormatException exception;
     private Set<String> acceptedNamespaces;
     protected Map<String, Extension> extensionNamespaces;
-    protected StringBuilder characterBuffer = new StringBuilder();
+    private StringBuilder characterBuffer = new StringBuilder();
 
     protected DelegatorHandler(LinkedList<String> elementStack, boolean strict) {
         this.elementStack = elementStack;
@@ -188,10 +188,8 @@ public class DelegatorHandler extends DefaultHandler {
     }
 
     protected void appendCharacterBuffer(char ch[], int start, int length) {
-        if (characterBuffer != null) {
-            for (int i = start; i < start + length; i++) {
-                characterBuffer.append(ch[i]);
-            }
+        for (int i = start; i < start + length; i++) {
+            characterBuffer.append(ch[i]);
         }
     }
 
@@ -200,9 +198,6 @@ public class DelegatorHandler extends DefaultHandler {
     }
 
     protected String getAndResetCharacterBuffer() {
-        if (characterBuffer == null) {
-            return null;
-        }
         String value = characterBuffer.toString();
         resetCharacterBuffer();
         return value;

--- a/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
@@ -79,7 +79,6 @@ import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
 class RSSHandler extends DelegatorHandler {
 
     private SiteMap sitemap;
-    private StringBuilder loc;
     private URL locURL;
     private ZonedDateTime lastMod;
     boolean valid;
@@ -88,7 +87,6 @@ class RSSHandler extends DelegatorHandler {
         super(elementStack, strict);
         sitemap = new SiteMap(url);
         sitemap.setType(SitemapType.RSS);
-        loc = new StringBuilder();
     }
 
     /*
@@ -109,47 +107,55 @@ class RSSHandler extends DelegatorHandler {
      */
     @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
-        if ("link".equals(currentElement()) || "guid".equals(currentElement())) {
+        if ("link".equals(localName)) {
             setLocURL();
-        } else if ("item".equals(currentElement())) {
+        } else if ("guid".equals(localName)) {
+            // accept as link if
+            // - a valid absolute URL (not a URN, UUID or similar)
+            // - and no <link> found yet
+            if (locURL == null) {
+                setLocURL();
+            }
+            resetCharacterBuffer();
+        } else if ("item".equals(localName)) {
             maybeAddSiteMapUrl();
-        } else if ("rss".equals(currentElement())) {
+        } else if ("rss".equals(localName)) {
             sitemap.setProcessed(true);
+        } else if ("pubDate".equals(localName)) {
+            String value = getAndResetCharacterBuffer();
+            if (value != null) {
+                lastMod = AbstractSiteMap.parseRSSTimestamp(value);
+                if (lastMod != null && "channel".equals(super.currentElementParent())) {
+                    sitemap.setLastModified(lastMod);
+                }
+            }
         }
     }
 
     /*
      * (non-Javadoc)
      * 
-     * @see crawlercommons.sitemaps.AbstractSiteMapSAXHandler#characters(char[],
-     * int, int)
+     * @see crawlercommons.sitemaps.sax.DelegatorHandler#characters(char[], int,
+     * int)
      */
     @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
         String localName = super.currentElement();
-        String value = String.valueOf(ch, start, length);
-        if ("pubDate".equals(localName)) {
-            lastMod = AbstractSiteMap.parseRSSTimestamp(value);
-            if (lastMod != null && "channel".equals(super.currentElementParent())) {
-                sitemap.setLastModified(lastMod);
-            }
-        } else if ("link".equals(localName)) {
-            loc.append(value);
-        } else if ("guid".equals(localName)) {
-            // accept as link if
-            // - a valid absolute URL (not a URN, UUID or similar)
-            // - and no <link> found yet
-            if (locURL == null) {
-                loc.append(value);
-            }
+        if ("pubDate".equals(localName) || "link".equals(localName) || "guid".equals(localName)) {
+            appendCharacterBuffer(ch, start, length);
         }
     }
 
+    @Override
     public AbstractSiteMap getSiteMap() {
         return sitemap;
     }
 
     private void setLocURL() {
+        String loc = getAndResetCharacterBuffer();
+        if (loc == null) {
+            return;
+        }
         String value = stripAllBlank(loc);
         if (value.isEmpty()) {
             return;
@@ -160,8 +166,6 @@ class RSSHandler extends DelegatorHandler {
         } catch (MalformedURLException e) {
             LOG.debug("Bad url: [{}]", value);
             LOG.trace("Can't create an entry with a bad URL", e);
-        } finally {
-            loc = new StringBuilder();
         }
     }
 
@@ -178,10 +182,12 @@ class RSSHandler extends DelegatorHandler {
         lastMod = null;
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
@@ -123,11 +123,9 @@ class RSSHandler extends DelegatorHandler {
             sitemap.setProcessed(true);
         } else if ("pubDate".equals(localName)) {
             String value = getAndResetCharacterBuffer();
-            if (value != null) {
-                lastMod = AbstractSiteMap.parseRSSTimestamp(value);
-                if (lastMod != null && "channel".equals(super.currentElementParent())) {
-                    sitemap.setLastModified(lastMod);
-                }
+            lastMod = AbstractSiteMap.parseRSSTimestamp(value);
+            if (lastMod != null && "channel".equals(super.currentElementParent())) {
+                sitemap.setLastModified(lastMod);
             }
         }
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -147,7 +147,7 @@ class XMLHandler extends DelegatorHandler {
         } else if (isStrictNamespace() && !currentElementNamespaceIsValid) {
             return;
         }
-        String localName = super.currentElement();
+        String localName = currentElement();
         if ("loc".equals(localName) || "url".equals(localName) || "changefreq".equals(localName) || "lastmod".equals(localName) || "priority".equals(localName)) {
             appendCharacterBuffer(ch, start, length);
         }
@@ -162,7 +162,7 @@ class XMLHandler extends DelegatorHandler {
         String value = null;
         if (loc != null) {
             value = stripAllBlank(loc);
-        } else if ("loc".equals(super.currentElement())) {
+        } else if ("loc".equals(currentElement())) {
             value = getAndResetCharacterBuffer();
         }
         if (value == null || isAllBlank(value)) {

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -63,7 +63,7 @@ import crawlercommons.sitemaps.sax.extension.ExtensionHandler;
 class XMLHandler extends DelegatorHandler {
 
     private SiteMap sitemap;
-    private StringBuilder loc;
+    private String loc;
     private String lastMod;
     private String changeFreq;
     private String priority;
@@ -76,9 +76,9 @@ class XMLHandler extends DelegatorHandler {
         super(elementStack, strict);
         sitemap = new SiteMap(url);
         sitemap.setType(SitemapType.XML);
-        loc = new StringBuilder();
     }
 
+    @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         currentElementNamespace = uri;
         if (isExtensionNamespace(uri)) {
@@ -93,12 +93,15 @@ class XMLHandler extends DelegatorHandler {
         currentElementNamespaceIsValid = true;
 
         // flush any unclosed or missing URL element
-        if (loc.length() > 0 && ("loc".equals(localName) || "url".equals(localName))) {
-            if (!isAllBlank(loc)) {
+        if ("loc".equals(localName) || "url".equals(localName)) {
+            if (loc == null) {
+                loc = getAndResetCharacterBuffer();
+            }
+            if (loc != null && !isAllBlank(loc)) {
                 maybeAddSiteMapUrl();
                 return;
             }
-            loc = new StringBuilder();
+            loc = null;
             if ("url".equals(localName)) {
                 // reset also attributes
                 lastMod = null;
@@ -106,8 +109,10 @@ class XMLHandler extends DelegatorHandler {
                 priority = null;
             }
         }
+        resetCharacterBuffer();
     }
 
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if (isExtensionNamespace(uri)) {
             ExtensionHandler eh = getExtensionHandler(uri);
@@ -116,13 +121,24 @@ class XMLHandler extends DelegatorHandler {
         } else if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
             return;
         }
-        if ("url".equals(localName) && "urlset".equals(currentElementParent())) {
-            maybeAddSiteMapUrl();
+        if ("url".equals(localName)) {
+            if ("urlset".equals(currentElementParent())) {
+                maybeAddSiteMapUrl();
+            }
         } else if ("urlset".equals(localName)) {
             sitemap.setProcessed(true);
+        } else if ("loc".equals(localName)) {
+            loc = getAndResetCharacterBuffer();
+        } else if ("changefreq".equals(localName)) {
+            changeFreq = getAndResetCharacterBuffer();
+        } else if ("lastmod".equals(localName)) {
+            lastMod = getAndResetCharacterBuffer();
+        } else if ("priority".equals(localName)) {
+            priority = getAndResetCharacterBuffer();
         }
     }
 
+    @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
         if (isExtensionNamespace(currentElementNamespace)) {
             ExtensionHandler eh = getExtensionHandler(currentElementNamespace);
@@ -132,24 +148,26 @@ class XMLHandler extends DelegatorHandler {
             return;
         }
         String localName = super.currentElement();
-        String value = String.valueOf(ch, start, length);
-        if ("loc".equals(localName) || "url".equals(localName)) {
-            loc.append(value);
-        } else if ("changefreq".equals(localName)) {
-            changeFreq = value;
-        } else if ("lastmod".equals(localName)) {
-            lastMod = value;
-        } else if ("priority".equals(localName)) {
-            priority = value;
+        if ("loc".equals(localName) || "url".equals(localName) || "changefreq".equals(localName) || "lastmod".equals(localName) || "priority".equals(localName)) {
+            appendCharacterBuffer(ch, start, length);
         }
     }
 
+    @Override
     public AbstractSiteMap getSiteMap() {
         return sitemap;
     }
 
     private void maybeAddSiteMapUrl() {
-        String value = stripAllBlank(loc);
+        String value = null;
+        if (loc != null) {
+            value = stripAllBlank(loc);
+        } else if ("loc".equals(super.currentElement())) {
+            value = getAndResetCharacterBuffer();
+        }
+        if (value == null || isAllBlank(value)) {
+            return;
+        }
         try {
             // check that the value is a valid URL
             URL locURL = new URL(value);
@@ -171,7 +189,7 @@ class XMLHandler extends DelegatorHandler {
             LOG.debug("Bad url: [{}]", value);
             LOG.trace("Can't create an entry with a bad URL", e);
         } finally {
-            loc = new StringBuilder();
+            loc = null;
             lastMod = null;
             changeFreq = null;
             priority = null;
@@ -220,10 +238,12 @@ class XMLHandler extends DelegatorHandler {
         }
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         maybeAddSiteMapUrl();
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
@@ -54,7 +54,7 @@ import crawlercommons.sitemaps.AbstractSiteMap.SitemapType;
 class XMLIndexHandler extends DelegatorHandler {
 
     private SiteMapIndex sitemap;
-    private StringBuilder loc;
+    private String loc;
     private boolean locClosed;
     private Date lastMod;
     private int i = 0;
@@ -63,17 +63,17 @@ class XMLIndexHandler extends DelegatorHandler {
         super(elementStack, strict);
         sitemap = new SiteMapIndex(url);
         sitemap.setType(SitemapType.INDEX);
-        loc = new StringBuilder();
     }
 
+    @Override
     public void startElement(String uri, String localName, String qName, Attributes attributes) throws SAXException {
         // flush any unclosed or missing <sitemap> element
-        if (loc.length() > 0 && ("loc".equals(localName) || "sitemap".equals(localName))) {
+        if (loc != null && loc.length() > 0 && ("loc".equals(localName) || "sitemap".equals(localName))) {
             if (!isAllBlank(loc)) {
                 maybeAddSiteMap();
                 return;
             }
-            loc = new StringBuilder();
+            loc = null;
             if ("sitemap".equals(localName)) {
                 // reset also attributes
                 locClosed = false;
@@ -82,41 +82,55 @@ class XMLIndexHandler extends DelegatorHandler {
         }
     }
 
+    @Override
     public void endElement(String uri, String localName, String qName) throws SAXException {
         if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
             return;
         }
         if ("sitemap".equals(currentElement())) {
+            if (!locClosed) {
+                // closing </sitemap> without closed </loc>
+                // try text in <sitemap> as <loc>
+                loc = getAndResetCharacterBuffer();
+            }
             maybeAddSiteMap();
         } else if ("sitemapindex".equals(currentElement())) {
             sitemap.setProcessed(true);
+        } else if ("lastmod".equals(localName)) {
+            String value = getAndResetCharacterBuffer();
+            if (value != null) {
+                lastMod = SiteMap.convertToDate(value);
+            }
         } else if ("loc".equals(currentElement())) {
+            loc = getAndResetCharacterBuffer();
             locClosed = true;
         }
     }
 
+    @Override
     public void characters(char[] ch, int start, int length) throws SAXException {
         String localName = super.currentElement();
-        String value = String.valueOf(ch, start, length);
-        if ("loc".equals(localName)) {
-            loc.append(value);
-        } else if ("lastmod".equals(localName)) {
-            lastMod = SiteMap.convertToDate(value);
-        } else {
-            value = stripAllBlank(value);
-            if (!value.isEmpty() && !locClosed) {
-                // try non-whitespace text content as loc
-                // when no loc element has been specified
-                loc.append(value);
+        if ("loc".equals(localName) || "lastmod".equals(localName)) {
+            appendCharacterBuffer(ch, start, length);
+        } else if (!locClosed) {
+            // try non-whitespace text content as loc
+            // when no loc element has been specified
+            String value = stripAllBlank(String.valueOf(ch, start, length));
+            if (!value.isEmpty()) {
+                appendCharacterBuffer(value);
             }
         }
     }
 
+    @Override
     public AbstractSiteMap getSiteMap() {
         return sitemap;
     }
 
     private void maybeAddSiteMap() {
+        if (loc == null) {
+            return;
+        }
         String value = stripAllBlank(loc);
         try {
             // check that the value is a valid URL
@@ -128,15 +142,17 @@ class XMLIndexHandler extends DelegatorHandler {
             LOG.trace("Don't create an entry with a bad URL", e);
             LOG.debug("Bad url: [{}]", value);
         }
-        loc = new StringBuilder();
+        loc = null;
         locClosed = false;
         lastMod = null;
     }
 
+    @Override
     public void error(SAXParseException e) throws SAXException {
         maybeAddSiteMap();
     }
 
+    @Override
     public void fatalError(SAXParseException e) throws SAXException {
         maybeAddSiteMap();
     }

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
@@ -87,21 +87,21 @@ class XMLIndexHandler extends DelegatorHandler {
         if (isStrictNamespace() && !isAcceptedNamespace(uri)) {
             return;
         }
-        if ("sitemap".equals(currentElement())) {
+        if ("sitemap".equals(localName)) {
             if (!locClosed) {
                 // closing </sitemap> without closed </loc>
                 // try text in <sitemap> as <loc>
                 loc = getAndResetCharacterBuffer();
             }
             maybeAddSiteMap();
-        } else if ("sitemapindex".equals(currentElement())) {
+        } else if ("sitemapindex".equals(localName)) {
             sitemap.setProcessed(true);
         } else if ("lastmod".equals(localName)) {
             String value = getAndResetCharacterBuffer();
             if (value != null) {
                 lastMod = SiteMap.convertToDate(value);
             }
-        } else if ("loc".equals(currentElement())) {
+        } else if ("loc".equals(localName)) {
             loc = getAndResetCharacterBuffer();
             locClosed = true;
         }

--- a/src/main/java/crawlercommons/sitemaps/sax/extension/LinksHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/extension/LinksHandler.java
@@ -53,13 +53,4 @@ public class LinksHandler extends ExtensionHandler {
             }
         }
     }
-
-    @Override
-    public void endElement(String uri, String localName, String qName) throws SAXException {
-    }
-
-    @Override
-    public void characters(char[] ch, int start, int length) throws SAXException {
-    }
-
 }

--- a/src/main/java/crawlercommons/sitemaps/sax/extension/MobileHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/extension/MobileHandler.java
@@ -44,13 +44,6 @@ public class MobileHandler extends ExtensionHandler {
     }
 
     @Override
-    public void endElement(String uri, String localName, String qName) throws SAXException {
-    }
-
-    @Override
-    public void characters(char[] ch, int start, int length) throws SAXException {
-    }
-
     public ExtensionMetadata[] getAttributes() {
         if (mobileElementFound) {
             return mobileAttributes;
@@ -58,6 +51,7 @@ public class MobileHandler extends ExtensionHandler {
         return noMobileAttributes;
     }
 
+    @Override
     public void reset() {
         super.reset();
         mobileElementFound = false;

--- a/src/main/java/crawlercommons/sitemaps/sax/extension/VideoHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/extension/VideoHandler.java
@@ -18,14 +18,12 @@ package crawlercommons.sitemaps.sax.extension;
 
 import static crawlercommons.sitemaps.SiteMapParser.LOG;
 
-import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.TreeMap;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 
-import crawlercommons.sitemaps.SiteMap;
 import crawlercommons.sitemaps.extension.ExtensionMetadata;
 import crawlercommons.sitemaps.extension.VideoAttributes;
 import crawlercommons.sitemaps.extension.VideoAttributes.VideoPrice;
@@ -150,8 +148,7 @@ public class VideoHandler extends ExtensionHandler {
             }
             currAttr.setDuration(duration);
         } else if ("expiration_date".equals(localName)) {
-            ZonedDateTime dateTime = SiteMap.convertToZonedDateTime(value);
-            currAttr.setExpirationDate(dateTime);
+            currAttr.setExpirationDate(getDateValue(value));
         } else if ("rating".equals(localName)) {
             currAttr.setRating(getFloatValue(value));
         } else if ("view_count".equals(localName)) {


### PR DESCRIPTION
Buffer characters when characters(...) is called, instead of immediately processing the current character chunk:
- fixes errors (#225 and #226) when character chunks are interrupted by CDATA sections or character entities
- DelegatorHandler provides a character buffer, so that derived classes can append characters to it and finally get the buffered content
- includes code cleanup in all handler classes:
  - add `@Override` annotations
  - remove stubb method implementations
