### PR TITLE
Make mvn run parameterized tests, fixes #273

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.1-SNAPSHOT (yyyy-mm-dd)
+- ParameterizedTest not executed by mvn builds (sebastian-nagel) #273
 - [BasicNormalizer] Empty path before query to be normalized to `/` (Chaiavi, sebastian-nagel) #247
 - EffectiveTldFinder to validate returned domain names for length restrictions (sebastian-nagel, Chaiavi) #251
 - Upgrade unit tests to use JUnit v5.x and parameterized tests (Chaiavi) #249, #253, #255

--- a/pom.xml
+++ b/pom.xml
@@ -327,7 +327,7 @@
 		<maven-compiler-plugin.version>2.3.2</maven-compiler-plugin.version>
 		<maven-resources-plugin.version>2.5</maven-resources-plugin.version>
 		<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-		<maven-surfire-plugin.version>2.12</maven-surfire-plugin.version>
+		<maven-surfire-plugin.version>2.22.2</maven-surfire-plugin.version>
 		<maven-release-plugin.version>2.5.1</maven-release-plugin.version>
 		<maven-source-plugin.version>2.1.2</maven-source-plugin.version>
 		<maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
@@ -367,7 +367,7 @@
 
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
-			<artifactId>junit-jupiter-api</artifactId>
+			<artifactId>junit-jupiter-engine</artifactId>
 			<version>${junit.version}</version>
 			<scope>test</scope>
 		</dependency>

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -29,7 +29,7 @@ import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.jupiter.api.Assertions.*;
 
-class SimpleRobotRulesParserTest {
+public class SimpleRobotRulesParserTest {
     private static final String LF = "\n";
     private static final String CR = "\r";
     private static final String CRLF = "\r\n";


### PR DESCRIPTION
- make test classes public
- upgrade Maven surefire plugin to recent version