### PR TITLE
SimpleRobotRulesParser: Trim log messages, fixes #281

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.1-SNAPSHOT (yyyy-mm-dd)
+- SimpleRobotRulesParser: Trim log messages (jnioche, sebastian-nagel) #281
 - SimpleRobotRulesParser: counter _numWarnings not thread-safe (sebastian-nagel, kkrugler) #278
 - ParameterizedTest not executed by mvn builds (sebastian-nagel) #273
 - [BasicNormalizer] Empty path before query to be normalized to `/` (Chaiavi, sebastian-nagel) #247

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -561,6 +561,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
         }
 
         if (state._numWarnings < _maxWarnings) {
+            for (int i = 0; i < args.length; i++) {
+                if (args[i] instanceof String && ((String) args[i]).length() > 1024) {
+                    // clip overlong strings to prevent from overflows in log messages
+                    args[i] = ((String) args[i]).substring(0, 1024) + " ...";
+                }
+            }
             LOGGER.warn("\t " + msg, args);
         }
     }


### PR DESCRIPTION
- clip strings shown in log message to 1024 chars