### PR TITLE
Fix failure in travis build #318 (forbidden apis check failed)

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/extension/LinkAttributes.java
+++ b/src/main/java/crawlercommons/sitemaps/extension/LinkAttributes.java
@@ -19,6 +19,7 @@ package crawlercommons.sitemaps.extension;
 import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
@@ -117,7 +118,7 @@ public class LinkAttributes extends ExtensionMetadata {
         if (params != null) {
 
             for (Entry<String, String> entry : params.entrySet()) {
-                map.put(String.format(PARAMS_PREFIX, entry.getKey()), new String[] { entry.getValue() });
+                map.put(String.format(Locale.ROOT, PARAMS_PREFIX, entry.getKey()), new String[] { entry.getValue() });
             }
         }
         return Collections.unmodifiableMap(map);


### PR DESCRIPTION
- make String::format not depend on system locale
- fix error in [travis build #318](https://travis-ci.org/github/crawler-commons/crawler-commons/builds/698574058):
  ```
  [ERROR] Forbidden method invocation: java.lang.String#format(java.lang.String,java.lang.Object[]) [Uses default locale]
  [ERROR]   in crawlercommons.sitemaps.extension.LinkAttributes (LinkAttributes.java:120)
  ```

