### PR TITLE
Fix for NewsAttribute.equals() compares the instance variable PublicationDate with itself.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,7 @@ Current Development 1.1-SNAPSHOT (yyyy-mm-dd)
 - Upgrade unit tests to use JUnit v5.x and parameterized tests (Avi Hayun) #249, #253, #255
 - [Robots] Robots parser to always handle absolute sitemap URL even without valid base URL (pr3mar, kkrugler, sebastian-nagel) #240
 - Adding asMap() to ExtensionMetadata Interface #288
+- NewsAttribute.equals() compares the instance variable PublicationDate with itself. #289
 
 Release 1.0 (2019-03-19)
 - [Sitemaps] Unit tests depend on system timezone (kkrugler, sebastian-nagel) #238

--- a/src/main/java/crawlercommons/sitemaps/extension/NewsAttributes.java
+++ b/src/main/java/crawlercommons/sitemaps/extension/NewsAttributes.java
@@ -161,7 +161,7 @@ public class NewsAttributes extends ExtensionMetadata {
         return Objects.equals(name, that.name) //
                         && Objects.equals(language, that.language) //
                         && Objects.equals(title, that.title) //
-                        && Objects.equals(publicationDate, publicationDate) //
+                        && Objects.equals(publicationDate, that.publicationDate) //
                         && Objects.deepEquals(keywords, that.keywords) //
                         && Objects.deepEquals(genres, that.genres) //
                         && Objects.deepEquals(stockTickers, that.stockTickers);

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserExtensionTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserExtensionTest.java
@@ -183,7 +183,7 @@ public class SiteMapParserExtensionTest {
         assertEquals(true, asm instanceof SiteMap);
         SiteMap sm = (SiteMap) asm;
         assertEquals(1, sm.getSiteMapUrls().size());
-        ZonedDateTime dt = ZonedDateTime.parse("2008-11-23T00:00:00+00:00");
+        ZonedDateTime dt = ZonedDateTime.parse("2008-12-23T00:00:00+00:00");
         NewsAttributes expectedNewsAttributes = new NewsAttributes("The Example Times", "en", dt, "Companies A, B in Merger Talks");
         expectedNewsAttributes.setKeywords(new String[] { "business", "merger", "acquisition", "A", "B" });
         expectedNewsAttributes.setGenres(new NewsAttributes.NewsGenre[] { NewsAttributes.NewsGenre.PressRelease, NewsAttributes.NewsGenre.Blog });


### PR DESCRIPTION
Having NewsAttribute.equals compare the this/that publicationDate variables (was this/this publicationDate variables).

I also updated the unit test and verified that the date matches what is in sitemap-news.xml.

Fix for #291 