### PR TITLE
Improvements to BasicURLNormalizer

### DIFF
--- a/src/test/resources/normalizer/weirdToNormalizedUrls.csv
+++ b/src/test/resources/normalizer/weirdToNormalizedUrls.csv
@@ -1,7 +1,5 @@
 # Weird URL, Normalized URL
 
-# testNUTCH1098
-# -------------
 # check that % encoding is normalized
 http://foo.com/%66oo.html, http://foo.com/foo.html
 
@@ -34,17 +32,15 @@ http://foo.com/file.html%23cz, http://foo.com/file.html%23cz
 http://foo.com/fast/dir%2fcz, http://foo.com/fast/dir%2Fcz
 
 # check that control chars are encoded
-#http://foo.com/\u001a!, http://foo.com/%1A!
+http://foo.com/!, http://foo.com/%1A!
 
 # check that control chars are always encoded into 2 digits
-#http://foo.com/\u0001!, http://foo.com/%01!
+http://foo.com/!, http://foo.com/%01!
 
-# check encoding of spanish chars
-#http://mydomain.com/en Espa\u00F1ol.aspx, http://mydomain.com/en%20Espa%C3%B1ol.aspx
+# encoding of Spanish chars
+http://mydomain.com/en Español.aspx, http://mydomain.com/en%20Espa%C3%B1ol.aspx
 
 
-# testNUTCH2064
-# -------------
 # Ampersand and colon and other punctuation characters are not to be unescaped
 http://x.com/s?q=a%26b&m=10, http://x.com/s?q=a%26b&m=10
 http://x.com/show?http%3A%2F%2Fx.com%2Fb, http://x.com/show?http%3A%2F%2Fx.com%2Fb
@@ -53,9 +49,11 @@ http://google.com/search?q=c%2B%2B, http://google.com/search?q=c%2B%2B
 # do also not touch the query part which is application/x-www-form-urlencoded
 http://x.com/s?q=a+b, http://x.com/s?q=a+b
 
-# and keep Internationalized domain names http://bücher.de/ may be http://xn--bcher-kva.de/
-# but definitely not http://b%C3%BCcher.de/
-http://b\u00fccher.de/, http://b\u00fccher.de/
+# convert Internationalized Domain Names (IDNs) fro Unicode to Punycode #248
+# (definitely do not apply percent-encoding: http://b%C3%BCcher.de/)
+http://bücher.de/, http://xn--bcher-kva.de/
+http://êxample.com, http://xn--xample-hva.com/
+https://нэб.рф/, https://xn--90ax2c.xn--p1ai/
 
 # test whether percent-encoding works together with other normalizations
 http://x.com/./a/../%66.html, http://x.com/f.html
@@ -64,7 +62,7 @@ http://x.com/./a/../%66.html, http://x.com/f.html
 http://x.com/?x[y]=1, http://x.com/?x%5By%5D=1
 
 # boundary test for first character outside the ASCII range (U+0080)
-#http://x.com/foo\u0080, http://x.com/foo%C2%80
+http://x.com/foo, http://x.com/foo%C2%80
 http://x.com/foo%c2%80, http://x.com/foo%C2%80
 
 
@@ -119,7 +117,10 @@ http://foo.com/aa//bb/foo.html, http://foo.com/aa/bb/foo.html
 http://foo.com/aa/bb//foo.html, http://foo.com/aa/bb/foo.html
 http://foo.com//aa//bb//foo.html, http://foo.com/aa/bb/foo.html
 http://foo.com////aa////bb//foo.html, http://foo.com/aa/bb/foo.html
+http://foo.com////aa////bb////foo.html, http://foo.com/aa/bb/foo.html
 http://foo.com/aa?referer=http://bar.com, http://foo.com/aa?referer=http://bar.com
+# also normalize  /..  (already in the root directory)
+http://foo.com/.., http://foo.com/
 
 # check URLs without host (authority)
 file:///foo/bar.txt, file:///foo/bar.txt
@@ -132,3 +133,36 @@ http:///////, http:/
 http://example.com?,http://example.com/?
 http://example.com?a=1,http://example.com/?a=1
 
+# normalizing percent escapes #263
+https://www.last.fm/music/Prefuse+73/_/90%+of+My+Mind+Is+With+You,https://www.last.fm/music/Prefuse+73/_/90%25+of+My+Mind+Is+With+You
+
+# escape curly braces properly
+http://foo.com/{{stuff}} , http://foo.com/%7B%7Bstuff%7D%7D
+
+# special characters in path/query
+"http://www.example.com/a/c/../b/search?q=foobar""", http://www.example.com/a/b/search?q=foobar%22
+http://www.example.com/a/c/../b/search?q=foobar%, http://www.example.com/a/b/search?q=foobar%25
+http://www.example.com/a/c/../b/search?q=foobar<, http://www.example.com/a/b/search?q=foobar%3C
+http://www.example.com/a/c/../b/search?q=foobar>, http://www.example.com/a/b/search?q=foobar%3E
+http://www.example.com/a/c/../b/search?q=foobar^, http://www.example.com/a/b/search?q=foobar%5E
+http://www.example.com/a/c/../b/search?q=foobar`, http://www.example.com/a/b/search?q=foobar%60
+http://www.example.com/a/c/../b/search?q=foobar|, http://www.example.com/a/b/search?q=foobar%7C
+
+# escape percent sign if it's initial to an invalid escape sequence
+http://www.example.com/p%zz%77%v, http://www.example.com/p%25zzw%25v
+
+# boundary test: percent sign close to the end of string
+http://www.example.com/search?q=foobar%, http://www.example.com/search?q=foobar%25
+http://www.example.com/search?q=foobar%2, http://www.example.com/search?q=foobar%252
+http://www.example.com/search?q=foobar%25, http://www.example.com/search?q=foobar%25
+http://www.example.com/search?q=foobar%252, http://www.example.com/search?q=foobar%252
+
+# protocol to be lowercased
+HTTP://foo.com/, http://foo.com/
+
+# removal of trailing dot in hostname
+https://www.example.org./, https://www.example.org/
+
+# file:/ URLs
+file:/var/www/html/////./bar/index.html, file:/var/www/html/bar/index.html
+file:/var/www/html/foo/../bar/index.html, file:/var/www/html/bar/index.html


### PR DESCRIPTION
- better percent-encoding of URL paths and queries, fixes #263
- hostnames:
  * convert IDNs from Unicode to Punycode, fixes #248
  * remove trailing dot
- normalize path `/..` to `/`
- also normalize path of file:/ URLs

This PR applies the improvements done in Nutch's BasicURLNormalizer, see [NUTCH-2547](https://issues.apache.org/jira/browse/NUTCH-2547) and [NUTCH-2746](https://issues.apache.org/jira/browse/NUTCH-2746).

Note: the CSV test file contains control characters which are not displayed in the diff below. JUnit seems to work properly for this test cases.