### PR TITLE
[BasicNormalizer] decode percent-encoded host names, fixes #303

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.2-SNAPSHOT (yyyy-mm-dd)
+- [BasicNormalizer] decode percent-encoded host names (sebastian-nagel) #303
 - [SiteMapParser] Document options *strict* and *allowPartial* in SiteMapParser constructors (sebastian-nagel) #267
 - [Robots] Maximum values (crawl-delay and warnings): document and make visible (sebastian-nagel, Avi Hayun) #276
 - [sitemaps] Replace priority "NaN" by default value (sebastian-nagel) #296

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -33,6 +33,12 @@ public class BasicURLNormalizerTest {
     @ParameterizedTest
     @CsvFileSource(resources = "/normalizer/weirdToNormalizedUrls.csv")
     void testBasicNormalizer(String weirdUrl, String expectedNormalizedUrl) throws Exception {
-      Assertions.assertEquals(expectedNormalizedUrl, normalizer.filter(weirdUrl), "normalizing: " + weirdUrl);
+        Assertions.assertEquals(expectedNormalizedUrl, normalizer.filter(weirdUrl), "normalizing: " + weirdUrl);
+    }
+
+    @ParameterizedTest
+    @CsvFileSource(resources = "/normalizer/invalidUrls.csv")
+    void testBasicNormalizerExceptionCaught(String weirdUrl) throws Exception {
+        Assertions.assertEquals(null, normalizer.filter(weirdUrl), "normalizing: " + weirdUrl);
     }
 }

--- a/src/test/resources/normalizer/invalidUrls.csv
+++ b/src/test/resources/normalizer/invalidUrls.csv
@@ -1,0 +1,9 @@
+# Test with invalid URLs
+# - BasicURLNormalizer should return null
+# - but never throw an exception
+
+# invalid percent-encoded sequence in host name
+https://example%2Xcom/
+# not a valid UTF-8 sequence
+https://abc%FEdef.org/
+

--- a/src/test/resources/normalizer/weirdToNormalizedUrls.csv
+++ b/src/test/resources/normalizer/weirdToNormalizedUrls.csv
@@ -55,6 +55,9 @@ http://bücher.de/, http://xn--bcher-kva.de/
 http://êxample.com, http://xn--xample-hva.com/
 https://нэб.рф/, https://xn--90ax2c.xn--p1ai/
 
+# unescape percent-encoded characters also in IDNs
+https://www.0251-sachverst%c3%a4ndiger.de/, https://www.xn--0251-sachverstndiger-ozb.de/
+
 # test whether percent-encoding works together with other normalizations
 http://x.com/./a/../%66.html, http://x.com/f.html
 
@@ -77,6 +80,9 @@ http://foo.com/, http://foo.com/
 # check that host is lower cased
 http://Foo.Com/index.html, http://foo.com/index.html
 http://Foo.Com/index.html, http://foo.com/index.html
+
+# unescape percent characters in host names
+https://example%2Ecom/, https://example.com/
 
 # check that port number is normalized
 http://foo.com:80/index.html, http://foo.com/index.html


### PR DESCRIPTION
- decoded percent-encoded sequences in host names
- extend unit tests to host names including IDNs
- add unit test to verify that runtime exception caused by invalid percent-encoded sequences are properly caught