### PR TITLE
Normalize URL without a scheme, resolves #271

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.2-SNAPSHOT (yyyy-mm-dd)
+- [BasicNormalizer] Normalize URL without a scheme (Avi Hayun, sebastian-nagel) #271
 - EffectiveTldFinder: upgrade public suffix list / Download latest effective_tld_names.dat during Maven build (Richard Zowalla) #295, #302
 - [BasicNormalizer] decode percent-encoded host names (sebastian-nagel) #303
 - [SiteMapParser] Document options *strict* and *allowPartial* in SiteMapParser constructors (sebastian-nagel) #267

--- a/src/test/resources/normalizer/weirdToNormalizedUrls.csv
+++ b/src/test/resources/normalizer/weirdToNormalizedUrls.csv
@@ -166,6 +166,12 @@ http://www.example.com/search?q=foobar%252, http://www.example.com/search?q=foob
 # protocol to be lowercased
 HTTP://foo.com/, http://foo.com/
 
+# no protocol/scheme, see #271
+foo.com/index.html, http://foo.com/index.html
+# but do not break potentially valid URLs with less-used schemes
+ftp://foo.com/index.html, ftp://foo.com/index.html
+file:/path/index.html, file:/path/index.html
+
 # removal of trailing dot in hostname
 https://www.example.org./, https://www.example.org/
 


### PR DESCRIPTION
- prefix URL without a scheme with `http://`