### PR TITLE
Allow to normalize URLs in sitemaps, resolves #305

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/SiteMapTester.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapTester.java
@@ -24,6 +24,8 @@ import org.apache.commons.io.IOUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import crawlercommons.filters.basic.BasicURLNormalizer;
+
 /**
  * Sitemap Tool for recursively fetching all URL's from a sitemap (and all of
  * it's children)
@@ -46,6 +48,9 @@ public class SiteMapTester {
             LOG.error("                  if true sitemaps are required to use the standard namespace URI");
             LOG.error("  sitemap.extensions");
             LOG.error("                  if true enable sitemap extension parsing");
+            LOG.error("  sitemap.filter.urls");
+            LOG.error("                  if true filter and normalize all URLs found in the sitemap");
+            LOG.error("                  using crawlercommons.filters.basic.BasicURLNormalizer");
         } else {
             URL url = new URL(args[0]);
             String mt = (args.length > 1) ? args[1] : null;
@@ -63,12 +68,17 @@ public class SiteMapTester {
 
         LOG.info("Parsing {} {}", url, ((mt != null && !mt.isEmpty()) ? "as MIME type " + mt : ""));
 
-        boolean strictNamespace = new Boolean(System.getProperty("sitemap.strictNamespace"));
+        boolean strictNamespace = Boolean.getBoolean("sitemap.strictNamespace");
         saxParser.setStrictNamespace(strictNamespace);
 
-        boolean enableExtensions = new Boolean(System.getProperty("sitemap.extensions"));
+        boolean enableExtensions = Boolean.getBoolean("sitemap.extensions");
         if (enableExtensions) {
             saxParser.enableExtensions();
+        }
+
+        boolean enableURLFilter = Boolean.getBoolean("sitemap.filter.urls");
+        if (enableURLFilter) {
+            saxParser.setURLFilter(new BasicURLNormalizer());
         }
 
         AbstractSiteMap sm = null;

--- a/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/AtomHandler.java
@@ -137,7 +137,12 @@ class AtomHandler extends DelegatorHandler {
                 LOG.debug("Missing url");
                 LOG.trace("Can't create an entry with a missing URL");
             } else {
-                SiteMapURL sUrl = new SiteMapURL(loc.toString(), lastMod, null, null, valid);
+                String urlFiltered = urlFilter.apply(loc.toString());
+                if (urlFiltered == null) {
+                    LOG.debug("Filtered URL {}", loc.toString());
+                    return;
+                }
+                SiteMapURL sUrl = new SiteMapURL(urlFiltered, lastMod, null, null, valid);
                 sitemap.addSiteMapUrl(sUrl);
                 LOG.debug("  {}. {}", (++i), sUrl);
             }

--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -23,6 +23,7 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
@@ -49,6 +50,7 @@ public class DelegatorHandler extends DefaultHandler {
     private Set<String> acceptedNamespaces;
     protected Map<String, Extension> extensionNamespaces;
     private StringBuilder characterBuffer = new StringBuilder();
+    protected Function<String, String> urlFilter = (String url) -> url;
 
     protected DelegatorHandler(LinkedList<String> elementStack, boolean strict) {
         this.elementStack = elementStack;
@@ -94,6 +96,10 @@ public class DelegatorHandler extends DefaultHandler {
             return false;
         }
         return extensionNamespaces.containsKey(uri);
+    }
+
+    public void setURLFilter(Function<String, String> urlFilter) {
+        this.urlFilter = urlFilter;
     }
 
     protected void setException(UnknownFormatException exception) {
@@ -170,6 +176,7 @@ public class DelegatorHandler extends DefaultHandler {
             }
         }
         delegate.setExtensionNamespaces(extensionNamespaces);
+        delegate.setURLFilter(urlFilter);
     }
 
     @Override
@@ -273,4 +280,5 @@ public class DelegatorHandler extends DefaultHandler {
         }
         return charSeq.subSequence(start, end + 1).toString();
     }
+
 }

--- a/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/RSSHandler.java
@@ -161,6 +161,12 @@ class RSSHandler extends DelegatorHandler {
         try {
             // check that the value is a valid URL
             locURL = new URL(sitemap.getUrl(), value);
+            String urlFiltered = urlFilter.apply(locURL.toString());
+            if (urlFiltered == null) {
+                LOG.debug("Filtered URL {}", value);
+                return;
+            }
+            locURL = new URL(urlFiltered);
         } catch (MalformedURLException e) {
             LOG.debug("Bad url: [{}]", value);
             LOG.trace("Can't create an entry with a bad URL", e);

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLHandler.java
@@ -168,10 +168,15 @@ class XMLHandler extends DelegatorHandler {
         if (value == null || isAllBlank(value)) {
             return;
         }
+        String urlFiltered = urlFilter.apply(value);
+        if (urlFiltered == null) {
+            LOG.debug("Filtered URL {}", value);
+            return;
+        }
         try {
             // check that the value is a valid URL
-            URL locURL = new URL(value);
-            boolean valid = urlIsValid(sitemap.getBaseUrl(), value);
+            URL locURL = new URL(urlFiltered);
+            boolean valid = urlIsValid(sitemap.getBaseUrl(), locURL.toString());
             if (valid || !isStrict()) {
                 SiteMapURL sUrl = new SiteMapURL(locURL, valid);
                 sUrl.setLastModified(lastMod);

--- a/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/XMLIndexHandler.java
@@ -132,9 +132,14 @@ class XMLIndexHandler extends DelegatorHandler {
             return;
         }
         String value = stripAllBlank(loc);
+        String urlFiltered = urlFilter.apply(value);
+        if (urlFiltered == null) {
+            LOG.debug("Filtered URL {}", value);
+            return;
+        }
         try {
             // check that the value is a valid URL
-            URL locURL = new URL(value);
+            URL locURL = new URL(urlFiltered);
             SiteMap s = new SiteMap(locURL, lastMod);
             sitemap.addSitemap(s);
             LOG.debug("  {}. {}", (i + 1), s);


### PR DESCRIPTION
- extend SiteMapParser by methods to register a URLFilter (function) used to normalize or filter (if null is returned) URLs found in   sitemaps
- implement URL filtering in sitemap parsers / XML handlers
- add unit tests to verify URL filtering for text and XML sitemaps