### PR TITLE
Fix XXE vulnerability in Sitemap parser

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapParser.java
@@ -589,7 +589,11 @@ public class SiteMapParser {
         // support the use of an explicit namespace.
         factory.setNamespaceAware(true);
 
+        // Configure underlying parser features to reduce the risk of XXE attacks
+        // See https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java
         try {
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
             factory.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
         } catch (Exception e) {
             throw new RuntimeException("Failed to configure XML parser: " + e.toString());

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserTest.java
@@ -116,10 +116,8 @@ public class SiteMapParserTest {
 
     @Test
     public void testSitemapXXE() throws UnknownFormatException, IOException {
-        // Create a temporary file on disk that would be read if we were vulnerable to XXE
-        Path doNotVisit = Files.createTempFile("do-not-visit", ".txt");
-        doNotVisit.toFile().deleteOnExit();
-        Files.write(doNotVisit, "http://www.example.com/do-not-visit-here".getBytes(StandardCharsets.UTF_8));
+        // A file on disk that would be read if we were vulnerable to XXE
+        File doNotVisit = new File("src/test/resources/sitemaps/do-not-visit.txt");
 
         // Create a sitemap with an external entity referring to the local temporary file
         SiteMapParser parser = new SiteMapParser();
@@ -127,7 +125,7 @@ public class SiteMapParserTest {
         StringBuilder scontent = new StringBuilder(1024);
         scontent.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n")
                 .append("<!DOCTYPE urlset [\n")
-                .append("  <!ENTITY test SYSTEM \"file://" + doNotVisit + "\">\n")
+                .append("  <!ENTITY test SYSTEM \"file://" + doNotVisit.toPath().toAbsolutePath() + "\">\n")
                 .append("]>\n")
                 .append("<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n")
                 .append("  <url>\n")
@@ -139,7 +137,6 @@ public class SiteMapParserTest {
                 .append("    <lastmod>2019-06-19</lastmod>\n")
                 .append("  </url>\n")
                 .append("</urlset>");
-        // assertEquals("", scontent.toString());
         byte[] content = scontent.toString().getBytes(UTF_8);
 
         URL url = new URL("http://www.example.com/sitemap.xxe.xml");

--- a/src/test/resources/sitemaps/do-not-visit.txt
+++ b/src/test/resources/sitemaps/do-not-visit.txt
@@ -1,0 +1,1 @@
+http://www.example.com/do-not-visit-here


### PR DESCRIPTION
We've been using the Crawler Commons library in our product for a while now and recently received a vulnerability report from a security researcher. Upon investigation, we have discovered that the issue was caused by an insufficiently secure SAX parser configuration within the SitemapParser class.

In this PR I have added a test case to demonstrate an XXE attack by reading a local file via the SitemapParser. I've made a change in the parser to disable external entity resolution according to the [recommendations from OWASP](https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html#java) and now the tests work as expected, the invalid URL with an external entity is getting ignored during parsing. I've tried to enable the "http://apache.org/xml/features/disallow-doctype-decl" feature, but then sitemap parsing completely blows up when any DOCTYPE definitions are present and I wasn't sure we want to do that. Let me know if we actually want to go that far and completely disable doctype resolution (which IMO would be reasonable for sitemap parsing, but I'll leave it up to you).

Let me know if I could improve the pull request in any way.