### PR TITLE
Add a builder API for configuring the BasicURLNormalizer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,8 @@
 Crawler-Commons Change Log
 
 Current Development 1.2-SNAPSHOT (yyyy-mm-dd)
-- [URLs] Provide a builder class to configure the URL normalizer (aecio) #321
+- [URLs] Provide a builder class to configure the URL normalizer (aecio) #321, #324
+- [URLs] Make normalization of IDNs configurable (to ASCII or Unicode) via builder (aecio, sebastian-nagel) #324
 - [Sitemaps] Fix XXE vulnerability in Sitemap parser (kovyrin) #323
 - [URLs] Sorting the Query Parameters (aecio) #246, #309
 - [URLs] Allows to (optionally) remove common irrelevant query parameters (aecio) #309

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.2-SNAPSHOT (yyyy-mm-dd)
+- [URLs] Provide a builder class to configure the URL normalizer (aecio) #321
 - [Sitemaps] Fix XXE vulnerability in Sitemap parser (kovyrin) #323
 - [URLs] Sorting the Query Parameters (aecio) #246, #309
 - [URLs] Allows to (optionally) remove common irrelevant query parameters (aecio) #309

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -619,6 +619,8 @@ public class BasicURLNormalizer extends URLFilter {
              * cf. https://bugs.openjdk.java.net/browse/JDK-6806873
              */
             host = IDN.toASCII(host);
+        } else if (this.idnNormalization == IdnNormalization.UNICODE && host.contains("xn--")) {
+            host = IDN.toUnicode(host);
         }
 
         /* 4. trim a trailing dot */
@@ -641,6 +643,7 @@ public class BasicURLNormalizer extends URLFilter {
     public enum IdnNormalization {
         NONE,
         PUNYCODE,
+        UNICODE
     }
 
     /**
@@ -666,7 +669,8 @@ public class BasicURLNormalizer extends URLFilter {
         }
 
         /**
-         * Configures whether internationalized domain names (IDNs) should be converted to ASCII/Punycode.
+         * Configures whether internationalized domain names (IDNs) should be
+         * converted to ASCII/Punycode or Unicode.
          *
          * @param idnNormalization
          * @return this builder

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -16,6 +16,7 @@
 
 package crawlercommons.filters.basic;
 
+import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -23,9 +24,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvFileSource;
-import java.util.Arrays;
-import java.util.List;
-import java.util.TreeSet;
 
 /** Unit tests for BasicURLNormalizer. */
 public class BasicURLNormalizerTest {
@@ -50,9 +48,7 @@ public class BasicURLNormalizerTest {
 
     @Test
     public void testRemoveSessionQueryParameters() {
-        List<String> invalidParameters = Arrays
-            .asList("sid", "phpsessid", "sessionid", "jsessionid");
-        normalizer = new BasicURLNormalizer(new TreeSet<>(invalidParameters));
+        normalizer = BasicURLNormalizer.newBuilder().queryParamsToRemove(asList("sid", "phpsessid", "sessionid", "jsessionid")).build();
         normalizeTest("http://foo.com/foo.php?phpsessid=2Aa3ASdfasfdadf&a=1", "http://foo.com/foo.php?a=1");
         normalizeTest("http://foo.com/foo.php?phpsessid=2Aa3ASdfasfdadf&a=1&b", "http://foo.com/foo.php?a=1&b");
         normalizeTest("http://foo.com/foo.php?phpsessid=2Aa3ASdfasfdadf", "http://foo.com/foo.php");

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -54,6 +54,20 @@ public class BasicURLNormalizerTest {
         normalizeTest("http://foo.com/foo.php?phpsessid=2Aa3ASdfasfdadf", "http://foo.com/foo.php");
     }
 
+    @Test
+    public void testHostToUnicode() {
+        normalizer = BasicURLNormalizer.newBuilder().idnNormalization(BasicURLNormalizer.IdnNormalization.UNICODE).build();
+        normalizeTest("http://xn--schne-lua.xn--bcher-kva.de/", "http://schöne.bücher.de/");
+        normalizeTest("https://xn--90ax2c.xn--p1ai/", "https://нэб.рф/");
+    }
+
+    @Test
+    public void testNoIdnNormalization() {
+        normalizer = BasicURLNormalizer.newBuilder().idnNormalization(BasicURLNormalizer.IdnNormalization.NONE).build();
+        // leave the host name as is, even if it's mixed
+        normalizeTest("http://schöne.xn--bcher-kva.de/", "http://schöne.xn--bcher-kva.de/");
+    }
+
     private void normalizeTest(String weird, String normal) {
         assertEquals(normal, normalizer.filter(weird), "normalizing: " + weird);
     }


### PR DESCRIPTION
Usage example:
```
normalizer = BasicURLNormalizer.newBuilder()
  .idnNormalization(IdnNormalization.PUNYCODE)
  .queryParamsToRemove(
    asList("sid", "phpsessid", "sessionid", "jsessionid")
  )
  .build();
```

Closes #321.