### PR TITLE
Bump maven-compiler-plugin from 3.2.0 to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
 		<servlet-api.version>2.5</servlet-api.version>
 
 		<!-- Maven Plugin Dependencies -->
-		<maven-compiler-plugin.version>3.2.0</maven-compiler-plugin.version>
+		<maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
 		<maven-resources-plugin.version>2.5</maven-resources-plugin.version>
 		<maven-jar-plugin.version>2.4</maven-jar-plugin.version>
 		<maven-surfire-plugin.version>2.22.2</maven-surfire-plugin.version>


### PR DESCRIPTION
The upgrade to the most recent version of the compiler plugin fixes the error described in #331 (maven-compiler-plugin:jar:3.2.0 not found in central).