### PR TITLE
Improve robots check draft rfc compliance

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -163,13 +163,36 @@ public class SimpleRobotRules extends BaseRobotRules {
                 return true;
             }
 
+            boolean isAllowed = true;
+            int longestRuleMatch = Integer.MIN_VALUE;
             for (RobotRule rule : _rules) {
-                if (ruleMatches(pathWithQuery, rule._prefix)) {
-                    return rule._allow;
+                int matchLength = ruleMatches(pathWithQuery, rule._prefix);
+                if (matchLength == -1) {
+                    // See precedence-of-rules test case for an example
+                    // Some webmasters expect behavior close to google's, and this block is equivalent to:
+                    // https://github.com/google/robotstxt/blob/02bc6cdfa32db50d42563180c42aeb47042b4f0c/robots.cc#L605-L618
+                    // There are example robots.txt in the wild that benefit from this.
+                    // As of 2/7/2022, https://venmo.com/robots.txt for instance.
+                    if (rule._prefix.endsWith("index.htm") || rule._prefix.endsWith("index.html")) {
+                        matchLength = ruleMatches(pathWithQuery, rule._prefix.substring(0, rule._prefix.indexOf("index.htm")) + "$");
+                        if (matchLength == -1) {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
                 }
+
+                if (longestRuleMatch < matchLength) {
+                    longestRuleMatch = matchLength;
+                    isAllowed = rule.isAllow();
+                } else if (longestRuleMatch == matchLength) {
+                    isAllowed |= rule.isAllow();
+                }
+                // else we've already got a more specific rule, and this match doesn't matter
             }
 
-            return true;
+            return isAllowed;
         }
     }
 
@@ -197,7 +220,7 @@ public class SimpleRobotRules extends BaseRobotRules {
         }
     }
 
-    private boolean ruleMatches(String text, String pattern) {
+    private int ruleMatches(String text, String pattern) {
         int patternPos = 0;
         int textPos = 0;
 
@@ -223,7 +246,7 @@ public class SimpleRobotRules extends BaseRobotRules {
                 patternPos += 1;
                 if (patternPos >= patternEnd) {
                     // Pattern ends with '*', we're all good.
-                    return true;
+                    return pattern.length();
                 }
 
                 // TODO - don't worry about having two '*' in a row?
@@ -255,14 +278,14 @@ public class SimpleRobotRules extends BaseRobotRules {
 
                 // If we matched, we're all set, otherwise we failed
                 if (!matched) {
-                    return false;
+                    return -1;
                 }
             } else {
                 // See if the pattern from patternPos to wildcardPos matches the
                 // text starting at textPos
                 while ((patternPos < wildcardPos) && (textPos < textEnd)) {
                     if (text.charAt(textPos++) != pattern.charAt(patternPos++)) {
-                        return false;
+                        return -1;
                     }
                 }
             }
@@ -277,7 +300,11 @@ public class SimpleRobotRules extends BaseRobotRules {
         // We're at the end, so we have a match if the pattern was completely
         // consumed, and either we consumed all the text or we didn't have to
         // match it all (no '$' at end of the pattern)
-        return (patternPos == patternEnd) && ((textPos == textEnd) || !containsEndChar);
+        if ((patternPos == patternEnd) && ((textPos == textEnd) || !containsEndChar)) {
+            return pattern.length();
+        } else {
+            return -1;
+        }
     }
 
     /**

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -169,10 +169,13 @@ public class SimpleRobotRules extends BaseRobotRules {
                 int matchLength = ruleMatches(pathWithQuery, rule._prefix);
                 if (matchLength == -1) {
                     // See precedence-of-rules test case for an example
-                    // Some webmasters expect behavior close to google's, and this block is equivalent to:
+                    // Some webmasters expect behavior close to google's, and
+                    // this block is equivalent to:
                     // https://github.com/google/robotstxt/blob/02bc6cdfa32db50d42563180c42aeb47042b4f0c/robots.cc#L605-L618
-                    // There are example robots.txt in the wild that benefit from this.
-                    // As of 2/7/2022, https://venmo.com/robots.txt for instance.
+                    // There are example robots.txt in the wild that benefit
+                    // from this.
+                    // As of 2/7/2022, https://venmo.com/robots.txt for
+                    // instance.
                     if (rule._prefix.endsWith("index.htm") || rule._prefix.endsWith("index.html")) {
                         matchLength = ruleMatches(pathWithQuery, rule._prefix.substring(0, rule._prefix.indexOf("index.htm")) + "$");
                         if (matchLength == -1) {
@@ -189,7 +192,8 @@ public class SimpleRobotRules extends BaseRobotRules {
                 } else if (longestRuleMatch == matchLength) {
                     isAllowed |= rule.isAllow();
                 }
-                // else we've already got a more specific rule, and this match doesn't matter
+                // else we've already got a more specific rule, and this match
+                // doesn't matter
             }
 
             return isAllowed;

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -287,8 +287,7 @@ public class SimpleRobotRulesParserTest {
     }
 
     @ParameterizedTest
-    @CsvSource({
-            "False, False, http://www.domain.com/a",//
+    @CsvSource({ "False, False, http://www.domain.com/a",//
                     "False, False, http://www.domain.com/a/",//
                     "False, False, http://www.domain.com/a/bloh/foo.html",//
                     "True, True, http://www.domain.com/b",//
@@ -318,9 +317,8 @@ public class SimpleRobotRulesParserTest {
         rules = createRobotRules("Agent1", nutchRobotsTxt);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
 
-
-
-        // Note that SimpleRobotRulesParser now merges all matching user agent rules.
+        // Note that SimpleRobotRulesParser now merges all matching user agent
+        // rules.
         rules = createRobotRules("Agent5,Agent2,Agent1,Agent3,*", nutchRobotsTxt);
         assertEquals(isMergeAllowed, rules.isAllowed(urlStr));
     }
@@ -478,13 +476,7 @@ public class SimpleRobotRulesParserTest {
     @Test
     void testMultiWildcard() {
         // Make sure we only take the first wildcard entry.
-        final String simpleRobotsTxt =
-                "User-agent: *" + CRLF +
-                "Disallow: /index.html" + CRLF +
-                "Allow: /" + CRLF +
-                CRLF +
-                "User-agent: *" + CRLF +
-                "Disallow: /";
+        final String simpleRobotsTxt = "User-agent: *" + CRLF + "Disallow: /index.html" + CRLF + "Allow: /" + CRLF + CRLF + "User-agent: *" + CRLF + "Disallow: /";
 
         BaseRobotRules rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt);
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));

--- a/src/test/resources/robots/merge-rules.txt
+++ b/src/test/resources/robots/merge-rules.txt
@@ -1,0 +1,16 @@
+User-Agent: testy
+Disallow: /
+
+User-Agent: curl
+Disallow: /
+
+User-Agent: wget
+Allow: /foo/bar
+
+User-Agent: *
+User-Agent: wget
+Disallow: /foo/bar
+Disallow: /tmp/bar
+Allow: /ckh/bar
+
+

--- a/src/test/resources/robots/precedence-of-rules.txt
+++ b/src/test/resources/robots/precedence-of-rules.txt
@@ -1,0 +1,15 @@
+User-Agent: testy
+Disallow: /foo
+
+User-Agent: wget
+Allow: /
+Allow: /foo
+Allow: /index.html
+Disallow: /*
+
+User-Agent: testy
+Allow: /foo/bar
+Disallow: /foo/b*
+
+
+


### PR DESCRIPTION
This library suffers from multiple issues in processing robots.txt matches when compared to what's considered to be standard behavior. 

https://datatracker.ietf.org/doc/html/draft-rep-wg-topic-00 

- It doesn't merge multiple blocks for the same user agent. 
```
Crawlers MUST find the group that matches the product token exactly, 
   and then obey the rules of the group. If there is more than one 
   group matching the user-agent, the matching groups' rules MUST be 
   combined into one group. 
```
- It doesn't evaluate all matches to find the most specific. 
```
The most specific match found MUST be 
   used. The most specific match is the match that has the most octets. 
```
- When in conflict, it doesn't resolve conflicts correctly (because it doesn't eval them) 
```
If an allow and disallow rule is equivalent, the allow SHOULD be 
   used. 
```

This patch tries to address all of these issues.