### PR TITLE
[Robots.txt] RFC compliance: matching user-agent names when selecting rule blocks

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotsParser.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotsParser.java
@@ -17,6 +17,7 @@
 package crawlercommons.robots;
 
 import java.io.Serializable;
+import java.util.Collection;
 
 @SuppressWarnings("serial")
 public abstract class BaseRobotsParser implements Serializable {
@@ -37,6 +38,13 @@ public abstract class BaseRobotsParser implements Serializable {
      * "crawlerbot" as the agent name, because of splitting on spaces,
      * lower-casing, and the prefix match rule.
      * 
+     * @deprecated since 1.4 - replaced by {@link parseContent(String, byte[],
+     *             String, Collection)}. Passing a collection of robot names
+     *             gives users more control how user-agent and robot names are
+     *             matched. Passing a list of names is also more efficient as it
+     *             does not require to split the robot name string again and
+     *             again on every robots.txt file to be parsed.
+     * 
      * @param url
      *            URL that robots.txt content was fetched from. A complete and
      *            valid URL (e.g., https://example.com/robots.txt) is expected.
@@ -51,16 +59,40 @@ public abstract class BaseRobotsParser implements Serializable {
      *            (just the name portion, w/o version or other details)
      * @return robot rules.
      */
-
+    @Deprecated
     public abstract BaseRobotRules parseContent(String url, byte[] content, String contentType, String robotNames);
 
     /**
-     * The fetch of robots.txt failed, so return rules appropriate give the HTTP
-     * status code.
+     * Parse the robots.txt file in <i>content</i>, and return rules appropriate
+     * for processing paths by <i>userAgent</i>. Multiple agent names can be
+     * provided as collection. How agent names are matched against user-agent
+     * lines in the robots.txt depends on the implementing class.
+     * 
+     * @param url
+     *            URL that robots.txt content was fetched from. A complete and
+     *            valid URL (e.g., https://example.com/robots.txt) is expected.
+     *            Used to resolve relative sitemap URLs and for
+     *            logging/reporting purposes.
+     * @param content
+     *            raw bytes from the site's robots.txt file
+     * @param contentType
+     *            HTTP response header (mime-type)
+     * @param robotNames
+     *            name(s) of crawler, used to select rules from the robots.txt
+     *            file by matching the names against the user-agent lines in the
+     *            robots.txt file.
+     * @return robot rules.
+     */
+    public abstract BaseRobotRules parseContent(String url, byte[] content, String contentType, Collection<String> robotNames);
+
+    /**
+     * The fetch of robots.txt failed, so return rules appropriate for the given
+     * HTTP status code.
      * 
      * @param httpStatusCode
      *            a failure status code (NOT 2xx)
      * @return robot rules
      */
     public abstract BaseRobotRules failedFetch(int httpStatusCode);
+
 }

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -393,7 +393,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * 9309, section 2.2.1</a>
      * 
      * @param userAgent
-     *            user-agent product token
+     *            user-agent token to verify
      * @return true if the product token is valid
      */
     protected static boolean isValidUserAgentToObey(String userAgent) {
@@ -663,6 +663,8 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * "Crawlers MUST try to parse each line of the robots.txt file. Crawlers MUST use the parseable rules."
      * and https://github.com/google/robotstxt/issues/56
      * 
+     * This method may be overridden to implement non-standard user-agent matching.
+     * 
      * @param agentName user-agent, found in the <a href=
      * "https://www.rfc-editor.org/rfc/rfc9309.html#name-the-user-agent-line">
      * robots.txt user-agent line</a>
@@ -672,7 +674,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * 
      * @return true if the product token is match as token prefix
      */
-    private boolean userAgentProductTokenPrefixMatch(String agentName, Collection<String> targetTokens) {
+    protected boolean userAgentProductTokenPartialMatch(String agentName, Collection<String> targetTokens) {
         Matcher m = USER_AGENT_PRODUCT_TOKEN_MATCHER.matcher(agentName);
         return m.lookingAt() && targetTokens.contains(m.group());
     }
@@ -707,7 +709,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             } else if (agentName.equals("*") && !state.isMatchedRealName()) {
                 state.setMatchedWildcard(true);
                 state.setAddingRules(true);
-            } else if (targetNames.contains(agentName) || (!isValidUserAgentToObey(agentName) && userAgentProductTokenPrefixMatch(agentName, targetNames))) {
+            } else if (targetNames.contains(agentName) || (!isValidUserAgentToObey(agentName) && userAgentProductTokenPartialMatch(agentName, targetNames))) {
                 if (state.isMatchedWildcard()) {
                     // Clear rules of the wildcard user-agent found
                     // before the non-wildcard user-agent match.
@@ -731,7 +733,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             if (agentNameFull.equals("*") && !state.isMatchedRealName()) {
                 state.setMatchedWildcard(true);
                 state.setAddingRules(true);
-            } else if (userAgentProductTokenPrefixMatch(agentNameFull, targetNames)) {
+            } else if (userAgentProductTokenPartialMatch(agentNameFull, targetNames)) {
                 // match "butterfly" in the line "User-agent: Butterfly/1.0"
                 matched = true;
             } else {

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -957,6 +957,33 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules.isAllowed("http://www.fict.com/fish"));
     }
 
+    @Test
+    void testMatchingOfUserAgentNamesIndependentFromSequentialOrder() {
+        String url = "https://example.com/foo/bar";
+
+        /*
+         * URL is allowed for "crawler" but disallowed for "crawlerbot"
+         * independent from sequential ordering of rules
+         */
+
+        String robotsTxtBlock1 = "User-agent: crawlerbot\n" //
+                        + "Disallow: /foo/bar\n";
+        String robotsTxtBlock2 = "User-agent: crawler\n" //
+                        + "Allow: /foo/bar\n";
+
+        String[] robotsTxts = new String[2];
+        robotsTxts[0] = robotsTxtBlock1 + "\n" + robotsTxtBlock2;
+        robotsTxts[1] = robotsTxtBlock2 + "\n" + robotsTxtBlock1;
+
+        for (String robotsTxt : robotsTxts) {
+            String userAgent = "crawlerbot";
+            BaseRobotRules rules = createRobotRules(userAgent, robotsTxt);
+            assertFalse(rules.isAllowed(url));
+            rules = createRobotRules("crawler", robotsTxt);
+            assertTrue(rules.isAllowed(url));
+        }
+    }
+
     // https://github.com/crawler-commons/crawler-commons/issues/112
     @Test
     void testSitemapAtEndOfFile() {

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -36,7 +36,7 @@ public class SimpleRobotRulesParserTest {
     private static final String FAKE_ROBOTS_URL = "http://domain.com";
 
     private static BaseRobotRules createRobotRules(String crawlerName, String content) {
-        return createRobotRules(crawlerName, content.getBytes(UTF_8), false);
+        return createRobotRules(crawlerName, content.getBytes(UTF_8), true);
     }
 
     private static BaseRobotRules createRobotRules(String crawlerName, String content, boolean exactUserAgentMatching) {
@@ -263,7 +263,7 @@ public class SimpleRobotRulesParserTest {
                         + "Allow: /~mak" + LF //
                         + "Disallow: /" + CRLF;
 
-        BaseRobotRules rules = createRobotRules("WebCrawler/3.0", mixedEndingsRobotsTxt);
+        BaseRobotRules rules = createRobotRules("WebCrawler/3.0", mixedEndingsRobotsTxt, false);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
     }
 
@@ -333,13 +333,13 @@ public class SimpleRobotRulesParserTest {
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("UnhipBot/0.1", rfpExampleRobotsTxt);
+        rules = createRobotRules("UnhipBot/0.1", rfpExampleRobotsTxt, false);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
 
-        rules = createRobotRules("WebCrawler/3.0", rfpExampleRobotsTxt);
+        rules = createRobotRules("WebCrawler/3.0", rfpExampleRobotsTxt, false);
         assertTrue(rules.isAllowed(urlStr));
 
-        rules = createRobotRules("Excite/1.0", rfpExampleRobotsTxt);
+        rules = createRobotRules("Excite/1.0", rfpExampleRobotsTxt, false);
         assertTrue(rules.isAllowed(urlStr));
     }
 
@@ -422,7 +422,7 @@ public class SimpleRobotRulesParserTest {
 
         // Note that SimpleRobotRulesParser now merges all matching user agent
         // rules.
-        rules = createRobotRules("Agent5,Agent2,Agent1,Agent3,*", nutchRobotsTxt);
+        rules = createRobotRules("Agent5,Agent2,Agent1,Agent3,*", nutchRobotsTxt, false);
         assertEquals(isMergeAllowed, rules.isAllowed(urlStr));
     }
 
@@ -465,13 +465,13 @@ public class SimpleRobotRulesParserTest {
 
         BaseRobotRules rules;
 
-        rules = createRobotRules("Agent2", nutchRobotsTxt);
+        rules = createRobotRules("Agent2", nutchRobotsTxt, false);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
 
-        rules = createRobotRules("Agent3", nutchRobotsTxt);
+        rules = createRobotRules("Agent3", nutchRobotsTxt, false);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
 
-        rules = createRobotRules("Agent4", nutchRobotsTxt);
+        rules = createRobotRules("Agent4", nutchRobotsTxt, false);
         assertEquals(isAllowed, rules.isAllowed(urlStr));
     }
 
@@ -654,7 +654,7 @@ public class SimpleRobotRulesParserTest {
                         + "Disallow: /index.html" + CRLF //
                         + "Allow: /";
 
-        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt);
+        BaseRobotRules rules = createRobotRules("crawler2", simpleRobotsTxt, false);
         assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
         assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
     }
@@ -797,7 +797,7 @@ public class SimpleRobotRulesParserTest {
                         + "User-agent: qihoobot" + CR //
                         + "Disallow: /";
 
-        BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt);
+        BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt, false);
         assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
         rules = createRobotRules("googlebot", krugleRobotsTxt, true);
         assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
@@ -990,10 +990,10 @@ public class SimpleRobotRulesParserTest {
         BaseRobotRules rules = createRobotRules("One", simpleRobotsTxt);
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
-        rules = createRobotRules("Two", simpleRobotsTxt);
+        rules = createRobotRules("Two", simpleRobotsTxt, false);
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
-        rules = createRobotRules("Three", simpleRobotsTxt);
+        rules = createRobotRules("Three", simpleRobotsTxt, false);
         assertFalse(rules.isAllowed("http://www.fict.com/fish"));
 
         rules = createRobotRules("Any-darn-crawler", simpleRobotsTxt);

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -672,6 +672,27 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
+    void testAgentTokenMatch() {
+        // The user-agent token should be matched until the first non-token
+        // character,
+        // see https://github.com/google/robotstxt/issues/56
+        final String simpleRobotsTxt1 = "User-agent: foo/1.2" + CRLF //
+                        + "Disallow: /index.html" + CRLF //
+                        + "Allow: /";
+        final String simpleRobotsTxt2 = "User-agent: foo bar" + CRLF //
+                        + "Disallow: /index.html" + CRLF //
+                        + "Allow: /";
+
+        BaseRobotRules rules = createRobotRules("foo", simpleRobotsTxt1, true);
+        assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
+        assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
+
+        rules = createRobotRules("foo", simpleRobotsTxt2, true);
+        assertFalse(rules.isAllowed("http://www.domain.com/index.html"));
+        assertTrue(rules.isAllowed("http://www.domain.com/anypage.html"));
+    }
+
+    @Test
     void testUnsupportedFields() {
         // When we have a new field type that we don't know about.
         final String simpleRobotsTxt = "User-agent: crawler1" + CRLF //
@@ -1037,11 +1058,7 @@ public class SimpleRobotRulesParserTest {
 
         // exact user-agent matching: user-agent is matched if the entire
         // user-agent line is passed as one robot name (lower-case)
-        String[] butterflyRobotsFullList = { //
-        "butterfly", //
-                        "butterfly/1.0", //
-                        "mozilla/5.0 (compatible; butterfly/1.0; +http://labs.topsy.com/butterfly/) gecko/2009032608 firefox/3.0.8" //
-        };
+        String[] butterflyRobotsFullList = { "butterfly", "butterfly/1.0", "mozilla/5.0 (compatible; butterfly/1.0; +http://labs.topsy.com/butterfly/) gecko/2009032608 firefox/3.0.8" };
         rules = createRobotRules(butterflyRobotsFullList, robotsTxt, true);
         assertFalse(rules.isAllowed(url));
 


### PR DESCRIPTION
- add unit test to verify that the rule with the completely matched user-agent name is selected, and no partial prefix match is preferred (cf. also #192)