### PR TITLE
Enhance GitHub actions with actions/cache for caching maven artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,5 +25,15 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: 'maven'
 
+      - name: Set up cache for ~./m2/repository
+        uses: actions/cache@v2.1.6
+        with:
+          path: |
+            ~/.m2/repository
+            !~/.m2/repository/com/github/crawler-commons
+          key: maven-${{ matrix.java }}-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            java${{ matrix.java }}
+
       - name: Build
         run: mvn install javadoc:aggregate

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Current Development 1.3-SNAPSHOT (yyyy-mm-dd)
 - Upgrade Maven plugins (dependabot, Richard Zowalla, sebastian-nagel) #328, #329, #330, #331, #335, #336, #337, #338, #340, #341, #343, #356, #363. #364, #366
 - Enable Dependabot (Valery Yatsynovich) #327
 - Removes test dependency towards mockito-core (Richard Zowalla) #367
+- Enhance GitHub actions with actions/cache for caching maven artifacts (Richard Zowalla) #365
 
 Release 1.2 (2021-10-06)
 - [Sitemaps] Avoid calling java.net.URL::equals in equals method of sitemaps and extensions (sebastian-nagel) #322


### PR DESCRIPTION
# What does this PR do?

- Use actions/cache to prevent downloading 3rd party artifacts again and again (they are not changing that often)