### PR TITLE
Javadoc: ensure Javascript search is working, fixes #378

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -247,6 +247,28 @@
 					</execution>
 				</executions>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>${maven-javadoc-plugin.version}</version>
+				<configuration>
+					<links>
+						<link>https://docs.oracle.com/javase/8/docs/api/</link>
+					</links>
+					<source>${javac.src.version}</source>
+					<additionalJOptions>
+						<additionalJOption>${additionalJavadocOpts}</additionalJOption>
+					</additionalJOptions>
+				</configuration>
+				<executions>
+					<execution>
+						<id>attach-javadocs</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
 		</plugins>
 	</build>
 
@@ -297,6 +319,7 @@
 								</goals>
 								<configuration>
 									<quiet>true</quiet>
+									<additionalJOption>${additionalJavadocOpts}</additionalJOption>
 									<archive>
 										<manifest>
 											<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -334,6 +357,15 @@
 					</plugin>
 				</plugins>
 			</build>
+		</profile>
+		<profile>
+			<id>javadoc-no-module-directories</id>
+			<activation>
+				<jdk>[11,12)</jdk>
+			</activation>
+			<properties>
+				<additionalJavadocOpts>--no-module-directories</additionalJavadocOpts>
+			</properties>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
Only for JDK / Java 11, pass the option `--no-module-directories` when building javadocs:
- the issue #378 only affects Javadoc artifacts built with JDK 11 (but not JDK 8 and 17 - I didn't test other versions)
- the option `--no-module-directories` breaks Javadoc builds on JDK 17, so it's made sure it's only called for JDK 11
- according to [JDK-8215291](https://bugs.openjdk.org/browse/JDK-8215291) the issue is fixed for JDK 12 and later