### PR TITLE
[Robots.txt] Path analyse bug with url-decode if allow/disallow path contains escaped wild-card characters

### DIFF
--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -540,7 +540,7 @@ public class BasicURLNormalizer extends URLFilter {
      * characters which should be escaped according to <a
      * href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC3986</a>.
      */
-    private static String escapePath(String path) {
+    public static String escapePath(String path) {
         StringBuilder sb = new StringBuilder(path.length());
 
         // Traverse over all bytes in this URL

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -541,6 +541,10 @@ public class BasicURLNormalizer extends URLFilter {
      * href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC3986</a>.
      */
     public static String escapePath(String path) {
+        return escapePath(path, null);
+    }
+
+    public static String escapePath(String path, boolean[] extraEscapedBytes) {
         StringBuilder sb = new StringBuilder(path.length());
 
         // Traverse over all bytes in this URL
@@ -548,7 +552,7 @@ public class BasicURLNormalizer extends URLFilter {
         for (int i = 0; i < bytes.length; i++) {
             byte b = bytes[i];
             // Is this a control character?
-            if (b < 0 || escapedCharacters[b]) {
+            if (b < 0 || escapedCharacters[b] || (extraEscapedBytes != null && extraEscapedBytes[b])) {
                 // Start escape sequence
                 sb.append('%');
 

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -18,10 +18,11 @@ package crawlercommons.robots;
 
 import java.io.Serializable;
 import java.net.URL;
-import java.net.URLDecoder;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import crawlercommons.filters.basic.BasicURLNormalizer;
 
 /**
  * Result from parsing a single robots.txt file - which means we get a set of
@@ -200,6 +201,10 @@ public class SimpleRobotRules extends BaseRobotRules {
         }
     }
 
+    static String escapePath(String urlPath) {
+        return BasicURLNormalizer.escapePath(BasicURLNormalizer.unescapePath(urlPath));
+    }
+
     private String getPath(String url, boolean getWithQuery) {
 
         try {
@@ -214,9 +219,16 @@ public class SimpleRobotRules extends BaseRobotRules {
                 path += "?" + query;
             }
 
-            // We used to lower-case the path, but Google says we need to do
-            // case-sensitive matching.
-            return URLDecoder.decode(path, "UTF-8");
+            /*
+             * We used to lower-case the path, but Google says we need to do
+             * case-sensitive matching.
+             * 
+             * However, we need to properly decode percent-encoded characters,
+             * but preserve those escaped characters which have special
+             * semantics in path matching (asterisk `*`, slash `/`, dollar `$`,
+             * etc.)
+             */
+            return escapePath(path);
         } catch (Exception e) {
             // If the URL is invalid, we don't really care since the fetch
             // will fail, so return the root.

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -786,15 +786,14 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      * <code>$</code>, etc.) are left as is (do not decode if percent-encoded).
      * </ul>
      * 
-     * This method uses {@link SimpleRobotRules#escapePath(String)} which is
-     * used to normalize the URL path before matching against allow/disallow
-     * rules.
+     * This method uses {@link SimpleRobotRules#escapePath(String, boolean[])}
+     * to normalize the URL path before matching against allow/disallow rules.
      * 
      * @param path
      * @return clean and encoded path
      */
     private String normalizePathDirective(String path) {
-        return SimpleRobotRules.escapePath(path.trim());
+        return SimpleRobotRules.escapePath(path.trim(), null);
     }
 
     /**

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -284,11 +284,20 @@ public class SimpleRobotRulesParserTest {
                     "True, /$, https://www.example.com/foobar", //
                     "True, /%24, https://www.example.com/", //
                     "False, /%24, https://www.example.com/%24100", //
+                    "False, /%24, https://www.example.com/$100", //
                     "True, /search/%2A/, https://www.example.com/search/foobar/", //
                     "False, /search/%2A/, https://www.example.com/search/%2A/", //
                     "False, /search/%2A/, https://www.example.com/search/%2a/", //
                     "False, /search/%2a/, https://www.example.com/search/%2a/", //
+                    "False, /search/%2a/, https://www.example.com/search/*/", //
                     "False, /search/*/, https://www.example.com/search/foobar/", //
+                    // examples from RFC 9309
+                    "False, /path/file-with-a-%2A.html, https://www.example.com/path/file-with-a-*.html", //
+                    "True, /path/file-with-a-%2A.html, https://www.example.com/path/file-with-a-foo.html", //
+                    "False, /path/file-with-a-%2A.html, https://www.example.com/path/file-with-a-%2A.html", //
+                    "False, /path/foo-%24, https://www.example.com/path/foo-$", //
+                    "True, /path/foo-%24, https://www.example.com/path/foo-", //
+                    "False, /path/foo-%24, https://www.example.com/path/foo-%24", //
     })
     void testEscapedPaths(boolean isAllowed, String disallowPath, String urlStr) {
         final String simpleRobotsTxt = "User-agent: *" + CRLF //

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -265,6 +265,40 @@ public class SimpleRobotRulesParserTest {
         // assertFalse(rules.isAllowed("https://www.example.com/bücher/book1.html"));
     }
 
+    @ParameterizedTest
+    @CsvSource({ // Tests for percent-encoded characters with special semantics
+                 // in allow/disallow statements:
+                 // (a) must not trim percent-encoded white space
+                    "True, /*%20, https://www.example.com/", //
+                    "False, /*%20, https://www.example.com/foobar%20/", //
+                    "True, /*%20, https://www.example.com/foobar/", //
+                    // (b) match literal %2F in URL path, but do not match a
+                    // slash
+                    "True, /*%2F*, https://www.example.com/path/index.html", //
+                    "False, /*%2F*, https://www.example.com/topic/9%2F11/index.html", //
+                    "False, /topic/9%2F11/, https://www.example.com/topic/9%2F11/index.html", //
+                    "False, /topic/9%2F11/, https://www.example.com/topic/9%2f11/index.html", //
+                    "False, /q?*mime=application%2Fpdf, https://www.example.com/q?mime=application%2Fpdf", //
+                    // (c) percent-encoded dollar and asterisk (*)
+                    "False, /$, https://www.example.com/", //
+                    "True, /$, https://www.example.com/foobar", //
+                    "True, /%24, https://www.example.com/", //
+                    "False, /%24, https://www.example.com/%24100", //
+                    "True, /search/%2A/, https://www.example.com/search/foobar/", //
+                    "False, /search/%2A/, https://www.example.com/search/%2A/", //
+                    "False, /search/%2A/, https://www.example.com/search/%2a/", //
+                    "False, /search/%2a/, https://www.example.com/search/%2a/", //
+                    "False, /search/*/, https://www.example.com/search/foobar/", //
+    })
+    void testEscapedPaths(boolean isAllowed, String disallowPath, String urlStr) {
+        final String simpleRobotsTxt = "User-agent: *" + CRLF //
+                        + "Disallow: " + disallowPath + CRLF //
+                        + "Allow: /";
+        BaseRobotRules rules = createRobotRules("mybot", simpleRobotsTxt);
+        String msg = urlStr + " should " + (isAllowed ? "not" : "") + " be disallowed by rule Disallow: " + disallowPath;
+        assertEquals(isAllowed, rules.isAllowed(urlStr), msg);
+    }
+
     @Test
     void testSimplestAllowAll() {
         final String simpleRobotsTxt = "User-agent: *" + CRLF //

--- a/src/test/resources/normalizer/weirdToNormalizedUrls.csv
+++ b/src/test/resources/normalizer/weirdToNormalizedUrls.csv
@@ -18,6 +18,8 @@ http://foo.com/%66oo.htm%1A, http://foo.com/foo.htm%1A
 
 # check that % decoder converts to upper case letters
 http://foo.com/%66oo.htm%c0, http://foo.com/foo.htm%C0
+https://www.example.com/search/%2a/, https://www.example.com/search/%2A/
+https://www.example.com/topic/9%2f11/, https://www.example.com/topic/9%2F11/
 
 # check that % decoder leaves encoded spaces alone
 http://foo.com/you%20too.html, http://foo.com/you%20too.html

--- a/src/test/resources/normalizer/weirdToNormalizedUrls.csv
+++ b/src/test/resources/normalizer/weirdToNormalizedUrls.csv
@@ -213,3 +213,7 @@ http://example.com/?, http://example.com/
 # Should not decode URL query data
 https://foo.com/?one/valid_query/without_%2F_params, https://foo.com/?one/valid_query/without_%2F_params
 http://foo.com/asdf/page.php?article%2F1234, http://foo.com/asdf/page.php?article%2F1234
+
+# examples from the robots.txt RFC 9309 - * and $ should be unchanged
+https://www.example.com/path/file-with-a-*.html, https://www.example.com/path/file-with-a-*.html
+https://www.example.com/path/foo-$, https://www.example.com/path/foo-$


### PR DESCRIPTION
(fixes #195)
- add unit tests to catch the issue
- percent-encode allow/disallow paths and URL paths before/during rule matching
- decode characters where necessary
- match paths containing `*` or `$`: percent-encoded in rules because of the special meaning. See also google/robotstxt#57 for clarification about the correct behavior.
- minor changes in BasicURLNormalizer to be able to use the provided path encoding/decoding methods