### PR TITLE
Generate JaCoCo reports when testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,26 @@
 
 		<plugins>
 			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>0.8.10</version>
+				<executions>
+					<execution>
+						<id>prepare-agent</id>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>post-unit-test</id>
+						<phase>test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>${maven-jar-plugin.version}</version>
@@ -188,7 +208,7 @@
 					<systemPropertyVariables>
 						<test.build.data>${project.basedir}/target/test-data/</test.build.data>
 					</systemPropertyVariables>
-					<argLine>-Xmx512m</argLine>
+					<argLine>@{argLine} -Xmx512m</argLine>
 					<forkCount>2</forkCount>
 					<testFailureIgnore>false</testFailureIgnore>
 				</configuration>


### PR DESCRIPTION
Fixes #409

![image](https://github.com/crawler-commons/crawler-commons/assets/218319/34f2967b-6f6e-42ab-ade2-9f4728c4a359)

I have put a secret COVERALLS_REPO_TOKEN in the GH config, just in case @rzo1 wants to send the JaCoco results to [Coveralls](https://coveralls.io/github/crawler-commons/crawler-commons) ;-)