### PR TITLE
[Robots.txt] Add units test based on examples in RFC 9309

### DIFF
--- a/src/test/resources/robots/rfc9309-example-longest-match-robots.txt
+++ b/src/test/resources/robots/rfc9309-example-longest-match-robots.txt
@@ -1,0 +1,6 @@
+# RFC 9309, section 5.2. Longest Match
+# https://www.rfc-editor.org/rfc/rfc9309.html#section-5.2
+
+User-Agent: foobot
+Allow: /example/page/
+Disallow: /example/page/disallowed.gif

--- a/src/test/resources/robots/rfc9309-example-rule-group-merging.txt
+++ b/src/test/resources/robots/rfc9309-example-rule-group-merging.txt
@@ -1,0 +1,16 @@
+# RFC 9309, section 2.2.1. The User-Agent Line
+# https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.1
+
+user-agent: ExampleBot
+disallow: /foo
+disallow: /bar
+
+user-agent: ExampleBot
+disallow: /baz
+
+user-agent: *
+disallow: /foo
+disallow: /bar
+
+user-agent: BazBot
+disallow: /baz

--- a/src/test/resources/robots/rfc9309-example-simple-robots.txt
+++ b/src/test/resources/robots/rfc9309-example-simple-robots.txt
@@ -1,0 +1,18 @@
+# RFC 9309, section 5.1. Simple Example
+# https://www.rfc-editor.org/rfc/rfc9309.html#section-5.1
+
+User-Agent: *
+Disallow: *.gif$
+Disallow: /example/
+Allow: /publications/
+
+User-Agent: foobot
+Disallow:/
+Allow:/example/page.html
+Allow:/example/allowed.gif
+
+User-Agent: barbot
+User-Agent: bazbot
+Disallow: /example/page.html
+
+User-Agent: quxbot


### PR DESCRIPTION
This PR adds unit tests for all examples provided in [RFC 9309](https://www.rfc-editor.org/rfc/rfc9309.html). For the examples of paths containing percent-encoded characters the unit tests of [Google's RFC reference parser](https://github.com/google/robotstxt/blob/master/robots_test.cc) and the [errata](https://www.rfc-editor.org/errata/rfc9309) were consulted:
- `/foo/bar/\u30C4` resp. `/foo/bar/%E3%83%84` - see errata
- the paths `/foo/bar?baz=https://foo.bar` and `/foo/bar?baz=https%3A%2F%2Ffoo.bar` are matched "as is" without decoding or encoding also in the unit tests of the reference parser. See also the [discussion of #309](https://github.com/crawler-commons/crawler-commons/pull/309#discussion_r555784004) for crawler-commons' BasicURLNormalizer.
- `/foo/bar/%62%61%7A` in the robots.txt matches `/foo/bar/baz` - it's a minor improvement of SimpleRobotRulesParser over the reference parser
