### PR TITLE
[Robots.txt] Document effect of rules merging in combination with multiple agent names, fixes #423

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -22,8 +22,11 @@ import java.util.LinkedHashSet;
 import java.util.List;
 
 /**
- * Result from parsing a single robots.txt file - which means we get a set of
- * rules, and a crawl-delay.
+ * Result from parsing a single robots.txt file – a set of allow/disallow rules
+ * to check whether a given URL is allowed, and optionally a <a href=
+ * "https://en.wikipedia.org/wiki/Robots.txt#Crawl-delay_directive"
+ * >Crawl-delay</a> and <a
+ * href="https://www.sitemaps.org/protocol.html#submit_robots">Sitemap</a> URLs.
  */
 @SuppressWarnings("serial")
 public abstract class BaseRobotRules implements Serializable {
@@ -52,10 +55,17 @@ public abstract class BaseRobotRules implements Serializable {
         _crawlDelay = crawlDelay;
     }
 
+    /**
+     * @return whether to defer visits to the server
+     */
     public boolean isDeferVisits() {
         return _deferVisits;
     }
 
+    /**
+     * Indicate to defer visits to the server, e.g. to wait until the robots.txt
+     * becomes available.
+     */
     public void setDeferVisits(boolean deferVisits) {
         _deferVisits = deferVisits;
     }
@@ -103,7 +113,7 @@ public abstract class BaseRobotRules implements Serializable {
 
     /**
      * Returns a string with the crawl delay as well as a list of sitemaps if
-     * they exist (and aren't more than 10)
+     * they exist (and aren't more than 10).
      */
     @Override
     public String toString() {

--- a/src/main/java/crawlercommons/robots/BaseRobotsParser.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotsParser.java
@@ -19,15 +19,16 @@ package crawlercommons.robots;
 import java.io.Serializable;
 import java.util.Collection;
 
+/** Robots.txt parser definition. */
 @SuppressWarnings("serial")
 public abstract class BaseRobotsParser implements Serializable {
 
     /**
      * Parse the robots.txt file in <i>content</i>, and return rules appropriate
      * for processing paths by <i>userAgent</i>. Note that multiple agent names
-     * may be provided as comma-separated values; the order of these shouldn't
-     * matter, as the file is parsed in order, and each agent name found in the
-     * file will be compared to every agent name found in robotNames.
+     * may be provided as comma-separated values. How agent names are matched
+     * against user-agent lines in the robots.txt depends on the implementing
+     * class.
      * 
      * Also note that names are lower-cased before comparison, and that any
      * robot name you pass shouldn't contain commas or spaces; if the name has
@@ -76,7 +77,7 @@ public abstract class BaseRobotsParser implements Serializable {
      * @param content
      *            raw bytes from the site's robots.txt file
      * @param contentType
-     *            HTTP response header (mime-type)
+     *            content type (MIME type) from HTTP response header
      * @param robotNames
      *            name(s) of crawler, used to select rules from the robots.txt
      *            file by matching the names against the user-agent lines in the

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -25,22 +25,24 @@ import java.util.stream.Collectors;
 import crawlercommons.filters.basic.BasicURLNormalizer;
 
 /**
- * Result from parsing a single robots.txt file - set of rules, and optionally a
- * <a href=
- * "https://en.wikipedia.org/wiki/Robots.txt#Crawl-delay_directive">crawl
- * -delay</a> and <a
- * href="https://www.sitemaps.org/protocol.html#submit_robots">sitemap</a> URLs.
- * The <a href="https://www.rfc-editor.org/rfc/rfc9309.html">Robots Exclusion
- * Protocol RFC 9309</a> is fully supported. This includes <a href=
+ * {@inheritDoc}
+ * 
+ * <p>
+ * Allow/disallow rules are matched following the <a
+ * href="https://www.rfc-editor.org/rfc/rfc9309.html">Robots Exclusion Protocol
+ * RFC 9309</a>. This includes <a href=
  * "https://developers.google.com/search/reference/robots_txt">Google's
  * robots.txt extensions</a> to the <a
- * href="http://www.robotstxt.org/robotstxt.html">original RFC draft</a> are
- * covered: the <code>Allow</code> directive, <code>$</code>/<code>*</code>
- * special characters and precedence of more specific patterns
+ * href="http://www.robotstxt.org/robotstxt.html">original RFC draft</a>: the
+ * <code>Allow</code> directive, <code>$</code>/<code>*</code> special
+ * characters and precedence of longer (more specific) patterns.
+ * </p>
  * 
+ * <p>
  * See also: <a
  * href="https://en.wikipedia.org/wiki/Robots_exclusion_standard">Robots
  * Exclusion on Wikipedia</a>
+ * </p>
  */
 
 @SuppressWarnings("serial")
@@ -58,6 +60,10 @@ public class SimpleRobotRules extends BaseRobotRules {
         String _prefix;
         boolean _allow;
 
+        /**
+         * A allow/disallow rule: a path prefix or pattern and whether it is
+         * allowed or disallowed.
+         */
         public RobotRule(String prefix, boolean allow) {
             _prefix = prefix;
             _allow = allow;
@@ -88,11 +94,6 @@ public class SimpleRobotRules extends BaseRobotRules {
             }
         }
 
-        /*
-         * (non-Javadoc)
-         * 
-         * @see java.lang.Object#hashCode()
-         */
         @Override
         public int hashCode() {
             final int prime = 31;
@@ -102,11 +103,6 @@ public class SimpleRobotRules extends BaseRobotRules {
             return result;
         }
 
-        /*
-         * (non-Javadoc)
-         * 
-         * @see java.lang.Object#equals(java.lang.Object)
-         */
         @Override
         public boolean equals(Object obj) {
             if (this == obj)
@@ -163,6 +159,9 @@ public class SimpleRobotRules extends BaseRobotRules {
         _rules.add(new RobotRule(prefix, allow));
     }
 
+    /**
+     * @return the list of allow/disallow rules
+     */
     public List<RobotRule> getRobotRules() {
         return this._rules;
     }
@@ -377,6 +376,11 @@ public class SimpleRobotRules extends BaseRobotRules {
     /**
      * Is our ruleset set up to allow all access?
      * 
+     * <p>
+     * Note: This is decided only based on the {@link RobotRulesMode} without
+     * inspecting the set of allow/disallow rules.
+     * </p>
+     * 
      * @return true if all URLs are allowed.
      */
     @Override
@@ -387,6 +391,11 @@ public class SimpleRobotRules extends BaseRobotRules {
     /**
      * Is our ruleset set up to disallow all access?
      * 
+     * <p>
+     * Note: This is decided only based on the {@link RobotRulesMode} without
+     * inspecting the set of allow/disallow rules.
+     * </p>
+     * 
      * @return true if no URLs are allowed.
      */
     @Override
@@ -394,11 +403,6 @@ public class SimpleRobotRules extends BaseRobotRules {
         return _mode == RobotRulesMode.ALLOW_NONE;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#hashCode()
-     */
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -408,11 +412,6 @@ public class SimpleRobotRules extends BaseRobotRules {
         return result;
     }
 
-    /*
-     * (non-Javadoc)
-     * 
-     * @see java.lang.Object#equals(java.lang.Object)
-     */
     @Override
     public boolean equals(Object obj) {
         if (this == obj)
@@ -433,9 +432,10 @@ public class SimpleRobotRules extends BaseRobotRules {
     }
 
     /*
-     * (non-Javadoc)
+     * {@inheritDoc}
      * 
-     * @see java.lang.Object#equals(java.lang.Object)
+     * In addition, the number of allow/disallow rules and the most specific
+     * rules by pattern length are shown (ten rules, at maximum).
      */
     @Override
     public String toString() {


### PR DESCRIPTION
Update documentation related to RFC 9309 compliance
- document effect of rules merging in combination with multiple agent names (#423)
- document that rules addressed to the wildcard agent are followed if none of the passed agent names matches - without any need to pass the wildcard agent name as one of the agent names
- complete robots.txt parser documentation
- use @inheritDoc to avoid duplicated documentation
- strip doc strings where inherited automatically per @Override annotations