### PR TITLE
[Robots.txt] Close groups of rules as defined in RFC 9309

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -47,10 +47,20 @@ public abstract class BaseRobotRules implements Serializable {
         _sitemaps = new LinkedHashSet<>();
     }
 
+    /**
+     * Get Crawl-delay (in milliseconds)
+     * 
+     * @return Crawl-delay defined in the robots.txt for the given agent name,
+     *         or {@link UNSET_CRAWL_DELAY} if not defined.
+     */
     public long getCrawlDelay() {
         return _crawlDelay;
     }
 
+    /**
+     * @param crawlDelay
+     *            Crawl-Delay in milliseconds
+     */
     public void setCrawlDelay(long crawlDelay) {
         _crawlDelay = crawlDelay;
     }

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -204,6 +204,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
          * something else has been found.
          */
         private boolean _finishedAgentFields;
+        /**
+         * Flag indicating whether the Crawl-delay was set for the given agent
+         * name (false means either not set at all or set for the wildcard
+         * agent).
+         */
+        private boolean _crawlDelaySetRealName;
 
         /*
          * Counter of warnings reporting invalid rules/lines in the robots.txt
@@ -266,8 +272,64 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             _curRules.addRule(prefix, allow);
         }
 
+        /**
+         * Set the Crawl-delay given the current parse state.
+         * 
+         * <p>
+         * The <a href=
+         * "https://en.wikipedia.org/wiki/Robots.txt#Crawl-delay_directive">Crawl
+         * -delay</a> is not part of RFC 9309 treating it (same as the Sitemap
+         * directive) as <a href=
+         * "https://www.rfc-editor.org/rfc/rfc9309.html#name-other-records">other
+         * records</a> and specifies: <cite>Parsing of other records MUST NOT
+         * interfere with the parsing of explicitly defined records</cite>.
+         * </p>
+         * 
+         * This methods sets the Crawl-delay in the robots rules
+         * ({@link BaseRobotRules#setCrawlDelay(long)})
+         * <ul>
+         * <li>always if the given agent name was matched in the current
+         * group</li>
+         * <li>for wildcard agent groups, only if the crawl-delay wasn't already
+         * defined for the given agent</li>
+         * </ul>
+         * 
+         * <p>
+         * In case of a multiple defined crawl-delay, resolve the conflict and
+         * override the current value if the value is shorter than the already
+         * defined one. But do not override a Crawl-delay defined for a specific
+         * agent by a value defined for the wildcard agent.
+         * </p>
+         */
         public void setCrawlDelay(long delay) {
-            _curRules.setCrawlDelay(delay);
+            if (_matchedRealName) {
+                // set crawl-delay for the given agent name
+                if (_crawlDelaySetRealName) {
+                    /*
+                     * Crawl-delay defined twice for the same agent or defined
+                     * for more than one of multiple agent names.
+                     * 
+                     * Resolve conflict and select shortest Crawl-delay.
+                     */
+                    if (_curRules.getCrawlDelay() > delay) {
+                        _curRules.setCrawlDelay(delay);
+                    }
+                } else {
+                    _curRules.setCrawlDelay(delay);
+                }
+                _crawlDelaySetRealName = true;
+            } else if (_curRules.getCrawlDelay() == BaseRobotRules.UNSET_CRAWL_DELAY) {
+                // not set yet
+                _curRules.setCrawlDelay(delay);
+            } else if (_curRules.getCrawlDelay() > delay) {
+                // Crawl-delay defined twice for the wildcard agent.
+                // Resolve conflict and select shortest Crawl-delay.
+                _curRules.setCrawlDelay(delay);
+            }
+        }
+
+        public void clearCrawlDelay() {
+            _curRules.setCrawlDelay(BaseRobotRules.UNSET_CRAWL_DELAY);
         }
 
         public SimpleRobotRules getRobotRules() {
@@ -662,36 +724,27 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                     break;
 
                 case CRAWL_DELAY:
-                parseState.setFinishedAgentFields(true);
                 handleCrawlDelay(parseState, token);
                     break;
 
                 case SITEMAP:
-                parseState.setFinishedAgentFields(true);
                 handleSitemap(parseState, token);
                     break;
 
                 case HTTP:
-                parseState.setFinishedAgentFields(true);
                 handleHttp(parseState, token);
                     break;
 
                 case UNKNOWN:
                 reportWarning(parseState, "Unknown directive in robots.txt file: {}", line);
-                parseState.setFinishedAgentFields(true);
                     break;
 
                 case MISSING:
                 reportWarning(parseState, "Unknown line in robots.txt file (size {}): {}", content.length, line);
-                parseState.setFinishedAgentFields(true);
                     break;
 
                 default:
                     // All others we just ignore
-                    // TODO KKr - which of these should be setting
-                    // finishedAgentFields to true?
-                    // TODO KKr - handle no-index
-                    // TODO KKr - handle request-rate and visit-time
                     break;
             }
         }
@@ -763,7 +816,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      */
     private void handleUserAgent(ParseState state, RobotToken token) {
         // If we are adding rules, and had already finished reading user agent
-        // fields, then we are in a new section, hence stop adding rules
+        // fields, then we are in a new section, hence stop adding rules.
         if (state.isAddingRules() && state.isFinishedAgentFields()) {
             state.setAddingRules(false);
         }
@@ -785,9 +838,10 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                 state.setAddingRules(true);
             } else if (targetNames.contains(agentName) || (!isValidUserAgentToObey(agentName) && userAgentProductTokenPartialMatch(agentName, targetNames))) {
                 if (state.isMatchedWildcard()) {
-                    // Clear rules of the wildcard user-agent found
-                    // before the non-wildcard user-agent match.
+                    // Clear rules and Crawl-delay of the wildcard user-agent
+                    // found before the non-wildcard user-agent match.
                     state.clearRules();
+                    state.clearCrawlDelay();
                 }
                 state.setMatchedRealName(true);
                 state.setAddingRules(true);
@@ -827,9 +881,10 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             }
             if (matched) {
                 if (state.isMatchedWildcard()) {
-                    // Clear rules of the wildcard user-agent found
-                    // before the non-wildcard user-agent match.
+                    // Clear rules and Crawl-delay of the wildcard user-agent
+                    // found before the non-wildcard user-agent match.
                     state.clearRules();
+                    state.clearCrawlDelay();
                 }
                 state.setMatchedRealName(true);
                 state.setAddingRules(true);

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -945,9 +945,11 @@ public class SimpleRobotRulesParserTest {
     @Test
     void testSelectCrawlDelayGroup() {
         final String robotsTxt = "User-Agent: bingbot" + CRLF //
-                        + "Crawl-delay: 1" + CRLF //
+                        + "Crawl-delay: 1" + CRLF + CRLF //
                         + "User-Agent: msnbot" + CRLF //
-                        + "Crawl-delay: 2" + CRLF //
+                        + "Crawl-delay: 2" + CRLF + CRLF //
+                        + "User-Agent: pinterestbot" + CRLF //
+                        + "Crawl-delay: 0.2" + CRLF + CRLF //
                         + "User-agent: *" + CRLF //
                         + "Disallow: /login" + CRLF //
                         + "Sitemap: http://www.example.com/sitemap.xml" + CRLF //
@@ -958,9 +960,9 @@ public class SimpleRobotRulesParserTest {
         List<String> sitemaps = List.of("http://www.example.com/sitemap.xml");
         for (Entry<String, Long> e : expectedCrawlDelays.entrySet()) {
             BaseRobotRules rules = createRobotRules(e.getKey(), robotsTxt);
-            assertEquals(e.getValue(), rules.getCrawlDelay());
+            assertEquals(e.getValue(), rules.getCrawlDelay(), "Crawl-delay for " + e.getKey() + " = " + e.getValue());
             assertFalse(rules.isAllowed("http://www.example.com/login"), "Disallow path /login for all agents");
-            assertFalse(rules.isAllowed("http://www.example.com/assets/"), "Disallow path /login for all agents");
+            assertFalse(rules.isAllowed("http://www.example.com/assets/"), "Disallow path /assets for all agents");
             assertTrue(rules.isAllowed("http://www.example.com/"), "Implicitly allowed");
             assertEquals(sitemaps, rules.getSitemaps());
         }

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -917,10 +917,28 @@ public class SimpleRobotRulesParserTest {
                         + "User-agent: qihoobot" + CR //
                         + "Disallow: /";
 
+        // Note: In compliance with RFC 9309, for Googlebot a specific
+        // Crawl-delay is set. However, Googlebot is not allowed to crawl any
+        // page (same as qihoobot).
         BaseRobotRules rules = createRobotRules("googlebot/2.1", krugleRobotsTxt, false);
-        assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertEquals(1000L, rules.getCrawlDelay());
+        assertFalse(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertFalse(rules.isAllowed("http://www.krugle.com/"));
+
         rules = createRobotRules("googlebot", krugleRobotsTxt, true);
-        assertTrue(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertEquals(1000L, rules.getCrawlDelay());
+        assertFalse(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertFalse(rules.isAllowed("http://www.krugle.com/"));
+
+        rules = createRobotRules("qihoobot", krugleRobotsTxt, true);
+        assertEquals(BaseRobotRules.UNSET_CRAWL_DELAY, rules.getCrawlDelay());
+        assertFalse(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertFalse(rules.isAllowed("http://www.krugle.com/"));
+
+        rules = createRobotRules("anybot", krugleRobotsTxt, true);
+        assertEquals(3000L, rules.getCrawlDelay());
+        assertFalse(rules.isAllowed("http://www.krugle.com/examples/index.html"));
+        assertTrue(rules.isAllowed("http://www.krugle.com/"));
     }
 
     /** Test selection of Crawl-delay directives in robots.txt (see #114) */


### PR DESCRIPTION
This PR addresses:
- Clarify behavior when to close blocks of multiple user-agents (resolves #390)
- Handle robots.txt with missing sections (and implicit master rules (resolves #114)

Changes:
- rule groups are closed as specified in RFC 9309: on a user-agent line, if at least one allow/disallow line was read before
- that is, Sitemap, Crawl-delay and other directives not covered by RFC 9309 do not finish a rule group
- the Crawl-delay is set independently from grouping:
  - it's set for a given agent or the wildcard agent
  - but a value defined for a specific agent is never set using a value defined for the wildcard agent
- unit tests are updated or added accordingly
  - for changed tests it's verified, that the RFC reference parser ([google/robotstxt](https://github.com/google/robotstxt)) behaves the same

This PR should unblock #245 (all unit tests added there should now pass).