### PR TITLE
Update README.md - add a link to repository map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 [![Build Status](https://github.com/crawler-commons/crawler-commons/workflows/crawler-commons%20build/badge.svg)](https://github.com/crawler-commons/crawler-commons/actions?query=workflow%3A%22crawler-commons+build%22)
 [![license](https://img.shields.io/github/license/crawler-commons/crawler-commons.svg?maxAge=2592000?style=plastic)](http://www.apache.org/licenses/LICENSE-2.0)
 [![Coverage Status](https://coveralls.io/repos/github/crawler-commons/crawler-commons/badge.svg?branch=master)](https://coveralls.io/github/crawler-commons/crawler-commons?branch=master)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/crawlercommonscrawlercommons/)
 
 # Overview
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/crawlercommonscrawlercommons/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.