### PR TITLE
Javadoc: fix links to Java core classes, fixes #417

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -272,13 +272,7 @@
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<version>${maven-javadoc-plugin.version}</version>
 				<configuration>
-					<links>
-						<link>https://docs.oracle.com/javase/8/docs/api/</link>
-					</links>
 					<source>${javac.src.version}</source>
-					<additionalJOptions>
-						<additionalJOption>${additionalJavadocOpts}</additionalJOption>
-					</additionalJOptions>
 				</configuration>
 				<executions>
 					<execution>
@@ -339,7 +333,6 @@
 								</goals>
 								<configuration>
 									<quiet>true</quiet>
-									<additionalJOption>${additionalJavadocOpts}</additionalJOption>
 									<archive>
 										<manifest>
 											<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
@@ -377,15 +370,6 @@
 					</plugin>
 				</plugins>
 			</build>
-		</profile>
-		<profile>
-			<id>javadoc-no-module-directories</id>
-			<activation>
-				<jdk>[11,12)</jdk>
-			</activation>
-			<properties>
-				<additionalJavadocOpts>--no-module-directories</additionalJavadocOpts>
-			</properties>
 		</profile>
 	</profiles>
 


### PR DESCRIPTION
Fixes to the Javadoc build
- remove work-around #378/#380
- remove link pointing to Java 8 core classes API docs

I've verified that for the resulting Javadoc (built with JDK 11, 17 and 21)
- there are no broken links to Java core classes
- the search box works (cf. #378)