### PR TITLE
Added https variants of namespaces

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.5-SNAPSHOT (yyyy-mm-dd)
+- [Sitemaps] Added https variants of namespaces (jnioche) #487
 - [Domains] Add version of public suffix list shipped with release packages enhancement (sebastian-nagel, Richard Zowalla) #433, #484
 - [Domains] Improve representation of public suffix match results by class EffectiveTLD (sebastian-nagel, Richard Zowalla) #478
 - Javadoc: fix links to Java core classes (sebastian-nagel, Richard Zowalla) #417, #483

--- a/src/main/java/crawlercommons/sitemaps/Namespace.java
+++ b/src/main/java/crawlercommons/sitemaps/Namespace.java
@@ -62,7 +62,8 @@ public class Namespace {
     public static final String[] NEWS = { //
                     "http://www.google.com/schemas/sitemap-news/0.9", //
                     "https://www.google.com/schemas/sitemap-news/0.9", //
-                    "http://www.google.com/schemas/sitemap-news/0.84" //
+                    "http://www.google.com/schemas/sitemap-news/0.84", //
+                    "https://www.google.com/schemas/sitemap-news/0.84" //
     };
 
     public static final String[] MOBILE = { //
@@ -70,9 +71,15 @@ public class Namespace {
                     "https://www.google.com/schemas/sitemap-mobile/1.0" //
     };
 
-    public static final String LINKS = "http://www.w3.org/1999/xhtml";
+    public static final String[] LINKS = {
+                    "http://www.w3.org/1999/xhtml",
+                    "https://www.w3.org/1999/xhtml"
+    };
 
-    public static final String PAGEMAPS = "http://www.google.com/schemas/sitemap-pagemap/1.0";
+    public static final String[] PAGEMAPS = {
+                    "http://www.google.com/schemas/sitemap-pagemap/1.0",
+                    "https://www.google.com/schemas/sitemap-pagemap/1.0"
+    };
 
     /**
      * In contradiction to the protocol specification ("The Sitemap must ...
@@ -102,8 +109,8 @@ public class Namespace {
         SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(IMAGE));
         SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(VIDEO));
         SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(NEWS));
-        SITEMAP_SUPPORTED_NAMESPACES.add(LINKS);
-        SITEMAP_SUPPORTED_NAMESPACES.add(PAGEMAPS);
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(LINKS));
+        SITEMAP_SUPPORTED_NAMESPACES.addAll(Arrays.asList(PAGEMAPS));
     }
 
     /**


### PR DESCRIPTION
The namespaces for extensions are set statically and these cannot be extended by the users (at least as far as I can tell).
This PR adds _https_ variants to some of the existing namespaces for the sake of completion as these are found in the wild.