### PR TITLE
Upgrade GitHub workflow actions v2 -> v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,10 +16,10 @@ jobs:
         java: [ 11, 17 ]
     name: Java ${{ matrix.java }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Setup JDK
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: ${{ matrix.java }}


### PR DESCRIPTION
Address [recently failed Github workflow](https://github.com/crawler-commons/crawler-commons/actions/runs/14651393972/job/41117803276?pr=500) by upgrading Github build actions from v2 to v4.