### PR TITLE
[Robots.txt] Extend API to allow to check java.net.URL objects

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -17,6 +17,7 @@
 package crawlercommons.robots;
 
 import java.io.Serializable;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -34,6 +35,8 @@ public abstract class BaseRobotRules implements Serializable {
     public static final long UNSET_CRAWL_DELAY = Long.MIN_VALUE;
 
     public abstract boolean isAllowed(String url);
+
+    public abstract boolean isAllowed(URL url);
 
     public abstract boolean isAllowAll();
 

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesTest.java
@@ -51,6 +51,33 @@ public class SimpleRobotRulesTest {
         assertTrue(expectedRules.equals(actualRules));
     }
 
+    @Test
+    public void testIsAllowed() throws MalformedURLException {
+        SimpleRobotRules rules = new SimpleRobotRules();
+        rules.addRule("/", true);
+        rules.addRule("/disallowed/", false);
+        rules.addRule("*?isallowed=false", false);
+        rules.sortRules();
+        URL url1 = new URL("https", "example.org", "index.html");
+        URL url2 = new URL("https", "example.org", "/disallowed/file.html");
+        URL url3 = new URL("https", "example.org", "");
+        URL url4 = new URL("https", "example.org", "?isallowed=false");
+        URL url5 = new URL("https", "example.org", "?isallowed=true");
+        URL url6 = new URL("https", "example.org", "/?isallowed=false");
+        assertTrue(rules.isAllowed(url1));
+        assertFalse(rules.isAllowed(url2));
+        assertTrue(rules.isAllowed(url3));
+        assertFalse(rules.isAllowed(url4));
+        assertTrue(rules.isAllowed(url5));
+        assertFalse(rules.isAllowed(url6));
+        assertTrue(rules.isAllowed(url1.toString()));
+        assertFalse(rules.isAllowed(url2.toString()));
+        assertTrue(rules.isAllowed(url3.toString()));
+        assertFalse(rules.isAllowed(url4.toString()));
+        assertTrue(rules.isAllowed(url5.toString()));
+        assertFalse(rules.isAllowed(url6.toString()));
+    }
+
     @ParameterizedTest
     @CsvSource({ "https://www.example.com/foo/../disallowed/bar.html", //
                     "https://www.example.com////disallowed/bar.html" })


### PR DESCRIPTION
The robots.txt API (defined in class BaseRobotRules) only allows to check a URL string whether it's allowed per robots.txt. In order to get the URL path and query components the URL string is parsed into a java.net.URL object. Since a crawler may have the URL object already at hand, stringifying and reparsing means extra unneeded work.

The PR adds a method `isAllowed(java.net.URL)` to avoid the extra work.