### PR TITLE
Add URLUtils class for URL resolution functionality

### DIFF
--- a/src/main/java/crawlercommons/utils/URLUtils.java
+++ b/src/main/java/crawlercommons/utils/URLUtils.java
@@ -1,0 +1,23 @@
+package crawlercommons.utils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+public class URLUtils {
+
+    /**
+     * Resolves a URL against a base URL.
+     *
+     * @param base the base URL
+     * @param spec the URL specification to resolve
+     * @return the resolved URL
+     * @throws MalformedURLException if the URL cannot be resolved
+     */
+    public static URL resolve(URL base, String spec) throws MalformedURLException {
+        try {
+            return base.toURI().resolve(spec).toURL();
+        } catch (Exception e) {
+            throw new MalformedURLException(e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a URL utility class with a static resolve(URL base, String spec) method. It encapsulates logic previously implemented with deprecated URL(URL, String) constructors, improving clarity and future maintainability.

The utility is intended to be used for replacing deprecated URL constructors in PR #524.

closes #525 