### PR TITLE
[Domains] Update unit tests after change in public suffix list

### DIFF
--- a/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
+++ b/src/test/java/crawlercommons/domains/EffectiveTldFinderTest.java
@@ -82,10 +82,10 @@ public class EffectiveTldFinderTest {
         assertEquals("uk", etld.getDomain());
         assertFalse(etld.isWildcard());
         assertEquals("uk", etld.getSuffix());
-        etld = EffectiveTldFinder.getEffectiveTLD("abc.def.bd");
-        assertEquals("def.bd", etld.getDomain());
+        etld = EffectiveTldFinder.getEffectiveTLD("justice.gov.ck");
+        assertEquals("gov.ck", etld.getDomain());
         assertTrue(etld.isWildcard());
-        assertEquals("*.bd", etld.getSuffix());
+        assertEquals("*.ck", etld.getSuffix());
     }
 
     @Test


### PR DESCRIPTION
- a change in the public suffix list (publicsuffix/list@30f4f42) causes a unit test failure
- this PR updates unit test: replace `*.bd` by `*.ck`

While the PSL (at least, the ICANN section) wasn't subject to frequent changes over several years, this was the second change this year causing an issue (after #532). Eventually, we should change the way how EffectiveTLFinder is tested.
