### PR TITLE
Replace deprecated URL constructors in unit tests

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
+++ b/src/main/java/crawlercommons/sitemaps/sax/DelegatorHandler.java
@@ -18,8 +18,6 @@ package crawlercommons.sitemaps.sax;
 
 import static crawlercommons.sitemaps.SiteMapParser.LOG;
 
-import java.net.MalformedURLException;
-import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.LinkedList;

--- a/src/main/java/crawlercommons/utils/URLUtils.java
+++ b/src/main/java/crawlercommons/utils/URLUtils.java
@@ -8,18 +8,23 @@ public class URLUtils {
 
     /**
      * Resolves a URL against a base URL.
-     *
-     * <p>Context: this helper was introduced when migrating callers from using
+     * 
+     * <p>
+     * Context: this helper was introduced when migrating callers from using
      * {@code java.net.URL} constructors to {@code URI}. The raw
      * {@code URI.resolve} semantics differ in a few corner cases from
-     * {@code URL}-based resolution did. To avoid scattering ad-hoc
-     * fixes across the codebase, the normalization logic lives here so resolution
-     * behavior is consistent and easier to maintain.</p>
-     *
-     * @param base the base URL
-     * @param spec the URL specification to resolve
+     * {@code URL}-based resolution did. To avoid scattering ad-hoc fixes across
+     * the codebase, the normalization logic lives here so resolution behavior
+     * is consistent and easier to maintain.
+     * </p>
+     * 
+     * @param base
+     *            the base URL
+     * @param spec
+     *            the URL specification to resolve
      * @return the resolved URL
-     * @throws MalformedURLException if the URL cannot be resolved
+     * @throws MalformedURLException
+     *             if the URL cannot be resolved
      */
     public static URL resolve(URL base, String spec) throws MalformedURLException {
         try {
@@ -29,10 +34,12 @@ public class URLUtils {
 
             String resolvedSpec = spec;
             if (spec.startsWith(":")) {
-                // Prepending "./" makes spec starting with colon a valid relative path reference.
+                // Prepending "./" makes spec starting with colon a valid
+                // relative path reference.
                 resolvedSpec = "./" + spec;
             } else if (spec.startsWith("?")) {
-                // Handle pure query targets, as browsers resolve differently than RFC 3986.
+                // Handle pure query targets, as browsers resolve differently
+                // than RFC 3986.
                 // Prepend the base path's file component to spec.
                 String basePath = base.getPath();
                 if (basePath != null && !basePath.isEmpty()) {

--- a/src/test/java/crawlercommons/domains/PaidLevelDomainTest.java
+++ b/src/test/java/crawlercommons/domains/PaidLevelDomainTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test;
 
 import java.net.InetAddress;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 
@@ -28,10 +30,10 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PaidLevelDomainTest {
 
     @Test
-    public final void testIPv4() throws MalformedURLException {
+    public final void testIPv4() throws MalformedURLException, URISyntaxException {
         assertEquals("1.2.3.4", PaidLevelDomain.getPLD("1.2.3.4"));
 
-        URL url = new URL("http://1.2.3.4:8080/a/b/c?_queue=1");
+        URL url = new URI("http://1.2.3.4:8080/a/b/c?_queue=1").toURL();
         assertEquals("1.2.3.4", PaidLevelDomain.getPLD(url));
     }
 
@@ -43,18 +45,18 @@ public class PaidLevelDomainTest {
     }
 
     @Test
-    public final void testIPv6() throws MalformedURLException, UnknownHostException {
+    public final void testIPv6() throws MalformedURLException, UnknownHostException, URISyntaxException {
         InetAddress inet = InetAddress.getByName("1080:0:0:0:8:800:200c:417a");
-        URL url = new URL("http", inet.getHostAddress(), 8080, "a/b/c");
+        URL url = new URI("http", null, inet.getHostAddress(), 8080, "/a/b/c", null, null).toURL();
         assertEquals("[1080:0:0:0:8:800:200c:417a]", PaidLevelDomain.getPLD(url));
     }
 
     @Test
-    public final void testStandardDomains() throws MalformedURLException {
+    public final void testStandardDomains() throws MalformedURLException, URISyntaxException {
         assertEquals("domain.com", PaidLevelDomain.getPLD("domain.com"));
         assertEquals("domain.com", PaidLevelDomain.getPLD("www.domain.com"));
         assertEquals("domain.com", PaidLevelDomain.getPLD("www.zzz.domain.com"));
-        assertEquals("domain.com", PaidLevelDomain.getPLD(new URL("https://www.zzz.domain.com:9000/a/b?c=d")));
+        assertEquals("domain.com", PaidLevelDomain.getPLD(new URI("https://www.zzz.domain.com:9000/a/b?c=d").toURL()));
     }
 
     @Test

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1282,7 +1282,6 @@ public class SimpleRobotRulesParserTest {
 
     @Test
     void testOverrideUserAgentMatcher() {
-        @SuppressWarnings("serial")
         BaseRobotsParser myRobotsParser = new SimpleRobotRulesParser() {
             @Override
             protected boolean userAgentProductTokenPartialMatch(String userAgent, Collection<String> targetTokens) {

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesTest.java
@@ -28,6 +28,8 @@ import java.io.ByteArrayOutputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -53,18 +55,18 @@ public class SimpleRobotRulesTest {
     }
 
     @Test
-    public void testIsAllowed() throws MalformedURLException {
+    public void testIsAllowed() throws MalformedURLException, URISyntaxException {
         SimpleRobotRules rules = new SimpleRobotRules();
         rules.addRule("/", true);
         rules.addRule("/disallowed/", false);
         rules.addRule("*?isallowed=false", false);
         rules.sortRules();
-        URL url1 = new URL("https", "example.org", "index.html");
-        URL url2 = new URL("https", "example.org", "/disallowed/file.html");
-        URL url3 = new URL("https", "example.org", "");
-        URL url4 = new URL("https", "example.org", "?isallowed=false");
-        URL url5 = new URL("https", "example.org", "?isallowed=true");
-        URL url6 = new URL("https", "example.org", "/?isallowed=false");
+        URL url1 = new URI("https://example.org/index.html").toURL();
+        URL url2 = new URI("https://example.org/disallowed/file.html").toURL();
+        URL url3 = new URI("https://example.org/").toURL();
+        URL url4 = new URI("https://example.org?isallowed=false").toURL();
+        URL url5 = new URI("https://example.org?isallowed=true").toURL();
+        URL url6 = new URI("https://example.org/?isallowed=false").toURL();
         assertTrue(rules.isAllowed(url1));
         assertFalse(rules.isAllowed(url2));
         assertTrue(rules.isAllowed(url3));
@@ -91,7 +93,7 @@ public class SimpleRobotRulesTest {
     @ParameterizedTest
     @CsvSource({ "https://www.example.com/foo/../disallowed/bar.html", //
                     "https://www.example.com////disallowed/bar.html" })
-    public void testUrlsNotNormalized(String urlNotNormalized) throws MalformedURLException {
+    public void testUrlsNotNormalized(String urlNotNormalized) throws URISyntaxException {
         SimpleRobotRules rules = new SimpleRobotRules();
         rules.addRule("/", true);
         rules.addRule("/disallowed/", false);
@@ -102,7 +104,7 @@ public class SimpleRobotRulesTest {
         // URL disallowed if properly normalized
         assertFalse(rules.isAllowed(urlNormalized));
         // base URL (path = "/") is allowed
-        String baseURL = new URL(new URL(urlNormalized), "/").toString();
+        String baseURL = (new URI(urlNormalized)).resolve("/").toString();
         assertTrue(rules.isAllowed(baseURL));
     }
 }

--- a/src/test/java/crawlercommons/sitemaps/SiteMapCrossSubmitValidatorTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapCrossSubmitValidatorTest.java
@@ -19,7 +19,8 @@ package crawlercommons.sitemaps;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Set;
 
@@ -27,11 +28,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class SiteMapCrossSubmitValidatorTest {
 
-    protected static SiteMap getSiteMap(String url, String content) throws UnknownFormatException, IOException {
+    protected static SiteMap getSiteMap(String url, String content) throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser(false);
         String contentType = "text/plain";
         byte[] bytes = content.getBytes(StandardCharsets.UTF_8);
-        AbstractSiteMap asm = parser.parseSiteMap(contentType, bytes, new URL(url));
+        AbstractSiteMap asm = parser.parseSiteMap(contentType, bytes, new URI(url).toURL());
         AbstractSiteMapTest.testSerializable(asm);
         assertEquals(false, asm.isIndex());
         assertEquals(true, asm instanceof SiteMap);

--- a/src/test/java/crawlercommons/sitemaps/SiteMapIndexTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapIndexTest.java
@@ -17,8 +17,8 @@
 package crawlercommons.sitemaps;
 
 import java.net.MalformedURLException;
-import java.net.URL;
-
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -39,12 +39,12 @@ public class SiteMapIndexTest {
     }
 
     @Test
-    public void testNPE() {
+    public void testNPE() throws URISyntaxException {
         SiteMapIndex index = new SiteMapIndex();
         index.addSitemap(new SiteMap("INVALID", "2020-06-18"));
         index.addSitemap(new SiteMap("https://example.com/sitemap1.xml", "2020-06-18"));
         try {
-            assertNotNull(index.getSitemap(new URL("https://example.com/sitemap1.xml")));
+            assertNotNull(index.getSitemap(new URI("https://example.com/sitemap1.xml").toURL()));
         } catch (MalformedURLException e) {
             // URL is valid
         }

--- a/src/test/java/crawlercommons/sitemaps/SiteMapParserExtensionTest.java
+++ b/src/test/java/crawlercommons/sitemaps/SiteMapParserExtensionTest.java
@@ -24,6 +24,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.HashMap;
@@ -53,11 +55,11 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testVideosSitemap() throws UnknownFormatException, IOException {
+    public void testVideosSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.VIDEO);
 
-        URL url = new URL("http://www.example.com/sitemap-video.xml");
+        URL url = new URI("http://www.example.com/sitemap-video.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-videos.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -67,8 +69,9 @@ public class SiteMapParserExtensionTest {
         Iterator<SiteMapURL> siter = sm.getSiteMapUrls().iterator();
 
         // first <loc> element: nearly all video attributes
-        VideoAttributes expectedVideoAttributes = new VideoAttributes(new URL("http://www.example.com/thumbs/123.jpg"), "Grilling steaks for summer",
-                        "Alkis shows you how to get perfectly done steaks every time", new URL("http://www.example.com/video123.flv"), new URL("http://www.example.com/videoplayer.swf?video=123"));
+        VideoAttributes expectedVideoAttributes = new VideoAttributes(new URI("http://www.example.com/thumbs/123.jpg").toURL(), "Grilling steaks for summer",
+                        "Alkis shows you how to get perfectly done steaks every time", new URI("http://www.example.com/video123.flv").toURL(), new URI(
+                                        "http://www.example.com/videoplayer.swf?video=123").toURL());
         expectedVideoAttributes.setDuration(600);
         ZonedDateTime dt = ZonedDateTime.parse("2009-11-05T19:20:30+08:00");
         expectedVideoAttributes.setExpirationDate(dt);
@@ -79,12 +82,12 @@ public class SiteMapParserExtensionTest {
         expectedVideoAttributes.setFamilyFriendly(true);
         expectedVideoAttributes.setTags(new String[] { "sample_tag1", "sample_tag2" });
         expectedVideoAttributes.setAllowedCountries(new String[] { "IE", "GB", "US", "CA" });
-        expectedVideoAttributes.setGalleryLoc(new URL("http://cooking.example.com"));
+        expectedVideoAttributes.setGalleryLoc(new URI("http://cooking.example.com").toURL());
         expectedVideoAttributes.setGalleryTitle("Cooking Videos");
         expectedVideoAttributes.setPrices(new VideoAttributes.VideoPrice[] { new VideoAttributes.VideoPrice("EUR", 1.99f, VideoAttributes.VideoPriceType.own) });
         expectedVideoAttributes.setRequiresSubscription(true);
         expectedVideoAttributes.setUploader("GrillyMcGrillerson");
-        expectedVideoAttributes.setUploaderInfo(new URL("http://www.example.com/users/grillymcgrillerson"));
+        expectedVideoAttributes.setUploaderInfo(new URI("http://www.example.com/users/grillymcgrillerson").toURL());
         expectedVideoAttributes.setLive(false);
         assertTrue(expectedVideoAttributes.isValid());
         VideoAttributes attr = (VideoAttributes) siter.next().getAttributesForExtension(Extension.VIDEO)[0];
@@ -96,16 +99,16 @@ public class SiteMapParserExtensionTest {
         // The current expected behavior is to not handle non-US locale price
         // values and set the price value to null if parsing as float value
         // fails.
-        expectedVideoAttributes = new VideoAttributes(new URL("http://www.example.com/thumbs/123-2.jpg"), "Grilling steaks for summer, episode 2",
-                        "Alkis shows you how to get perfectly done steaks every time", new URL("http://www.example.com/video123-2.flv"), null);
+        expectedVideoAttributes = new VideoAttributes(new URI("http://www.example.com/thumbs/123-2.jpg").toURL(), "Grilling steaks for summer, episode 2",
+                        "Alkis shows you how to get perfectly done steaks every time", new URI("http://www.example.com/video123-2.flv").toURL(), null);
         expectedVideoAttributes.setPrices(new VideoAttributes.VideoPrice[] { new VideoAttributes.VideoPrice("EUR", null, VideoAttributes.VideoPriceType.own) });
         attr = (VideoAttributes) siter.next().getAttributesForExtension(Extension.VIDEO)[0];
         assertNotNull(attr);
         assertEquals(expectedVideoAttributes, attr);
 
         // empty price, only type (purchase or rent) is indicated, see #221
-        expectedVideoAttributes = new VideoAttributes(new URL("http://www.example.com/thumbs/123-3.jpg"), "Grilling steaks for summer, episode 3",
-                        "Alkis shows you how to get perfectly done steaks every time", new URL("http://www.example.com/video123-3.flv"), null);
+        expectedVideoAttributes = new VideoAttributes(new URI("http://www.example.com/thumbs/123-3.jpg").toURL(), "Grilling steaks for summer, episode 3",
+                        "Alkis shows you how to get perfectly done steaks every time", new URI("http://www.example.com/video123-3.flv").toURL(), null);
         expectedVideoAttributes.setPrices(new VideoAttributes.VideoPrice[] { new VideoAttributes.VideoPrice(null, null, VideoAttributes.VideoPriceType.rent) });
         attr = (VideoAttributes) siter.next().getAttributesForExtension(Extension.VIDEO)[0];
         assertNotNull(attr);
@@ -113,11 +116,11 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testVideosSitemapTVShow() throws UnknownFormatException, IOException {
+    public void testVideosSitemapTVShow() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.VIDEO);
 
-        URL url = new URL("https://example.org/sitemap.xml");
+        URL url = new URI("https://example.org/sitemap.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-videos-tvshow.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -131,7 +134,7 @@ public class SiteMapParserExtensionTest {
         assertNotNull(attr);
 
         VideoAttributes expectedVideoAttributes = new VideoAttributes( //
-                        new URL("https://example.org/my-tv-show.jpg"), //
+                        new URI("https://example.org/my-tv-show.jpg").toURL(), //
                         "My TV Show! - Thu, Jun 05, 2025", //
                         "Dummy description", null, null);
         expectedVideoAttributes.setDuration(2459);
@@ -142,10 +145,10 @@ public class SiteMapParserExtensionTest {
         expectedVideoAttributes.setTags(new String[] { "talkshow", "interview", "example" });
         expectedVideoAttributes.setCategory("My TV Show!");
         expectedVideoAttributes.setRequiresSubscription(true);
-        expectedVideoAttributes.setContentLoc(new URL("https://example.org/video/video/23-13.mp4"));
-        expectedVideoAttributes.setPlayerLoc(new URL("https://example.org/video/embed/23-13"));
-        expectedVideoAttributes.addContentSegment(1287, new URL("https://example.org/video/video/23-13-1.mp4"));
-        expectedVideoAttributes.addContentSegment(1172, new URL("https://example.org/video/video/23-13-2.mp4"));
+        expectedVideoAttributes.setContentLoc(new URI("https://example.org/video/video/23-13.mp4").toURL());
+        expectedVideoAttributes.setPlayerLoc(new URI("https://example.org/video/embed/23-13").toURL());
+        expectedVideoAttributes.addContentSegment(1287, new URI("https://example.org/video/video/23-13-1.mp4").toURL());
+        expectedVideoAttributes.addContentSegment(1172, new URI("https://example.org/video/video/23-13-2.mp4").toURL());
         VideoAttributes.TVShow tvShow = new VideoAttributes.TVShow();
         tvShow.setShowTitle("My TV Show!");
         tvShow.setVideoType("full");
@@ -163,23 +166,23 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testImageSitemap() throws UnknownFormatException, IOException {
+    public void testImageSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.IMAGE);
 
-        URL url = new URL("http://www.example.com/sitemap-images.xml");
+        URL url = new URI("http://www.example.com/sitemap-images.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-images.xml", url);
 
         assertEquals(false, asm.isIndex());
         assertEquals(true, asm instanceof SiteMap);
         SiteMap sm = (SiteMap) asm;
         assertEquals(1, sm.getSiteMapUrls().size());
-        ImageAttributes imageAttributes1 = new ImageAttributes(new URL("http://example.com/image.jpg"));
-        ImageAttributes imageAttributes2 = new ImageAttributes(new URL("http://example.com/photo.jpg"));
+        ImageAttributes imageAttributes1 = new ImageAttributes(new URI("http://example.com/image.jpg").toURL());
+        ImageAttributes imageAttributes2 = new ImageAttributes(new URI("http://example.com/photo.jpg").toURL());
         imageAttributes2.setCaption("This is the caption.");
         imageAttributes2.setGeoLocation("Limerick, Ireland");
         imageAttributes2.setTitle("Example photo shot in Limerick, Ireland");
-        imageAttributes2.setLicense(new URL("https://creativecommons.org/licenses/by/4.0/legalcode"));
+        imageAttributes2.setLicense(new URI("https://creativecommons.org/licenses/by/4.0/legalcode").toURL());
 
         for (SiteMapURL su : sm.getSiteMapUrls()) {
             assertNotNull(su.getAttributesForExtension(Extension.IMAGE));
@@ -193,13 +196,12 @@ public class SiteMapParserExtensionTest {
         }
     }
 
-    @SuppressWarnings("serial")
     @Test
-    public void testXHTMLLinksSitemap() throws UnknownFormatException, IOException, MalformedURLException {
+    public void testXHTMLLinksSitemap() throws UnknownFormatException, IOException, MalformedURLException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.LINKS);
 
-        URL url = new URL("http://www.example.com/sitemap-links.xml");
+        URL url = new URI("http://www.example.com/sitemap-links.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-links.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -207,8 +209,8 @@ public class SiteMapParserExtensionTest {
         SiteMap sm = (SiteMap) asm;
         assertEquals(3, sm.getSiteMapUrls().size());
         // all three pages share the same links attributes
-        LinkAttributes[] linkAttributes = new LinkAttributes[] { new LinkAttributes(new URL("http://www.example.com/deutsch/")),
-                        new LinkAttributes(new URL("http://www.example.com/schweiz-deutsch/")), new LinkAttributes(new URL("http://www.example.com/english/")) };
+        LinkAttributes[] linkAttributes = new LinkAttributes[] { new LinkAttributes(new URI("http://www.example.com/deutsch/").toURL()),
+                        new LinkAttributes(new URI("http://www.example.com/schweiz-deutsch/").toURL()), new LinkAttributes(new URI("http://www.example.com/english/").toURL()) };
         linkAttributes[0].setParams(new HashMap<String, String>() {
             {
                 put("rel", "alternate");
@@ -241,11 +243,11 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testNewsSitemap() throws UnknownFormatException, IOException {
+    public void testNewsSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.NEWS);
 
-        URL url = new URL("http://www.example.org/sitemap-news.xml");
+        URL url = new URI("http://www.example.org/sitemap-news.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-news.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -283,11 +285,11 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testMobileSitemap() throws UnknownFormatException, IOException {
+    public void testMobileSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.enableExtension(Extension.MOBILE);
 
-        URL url = new URL("http://www.example.org/sitemap-mobile.xml");
+        URL url = new URI("http://www.example.org/sitemap-mobile.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/sitemap-mobile.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -308,12 +310,12 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testShinpaideshuNewsSitemap() throws UnknownFormatException, IOException {
+    public void testShinpaideshuNewsSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.setStrictNamespace(true);
         parser.enableExtension(Extension.NEWS);
 
-        URL url = new URL("https://shinpaideshou.wordpress.com/news-sitemap.xml");
+        URL url = new URI("https://shinpaideshou.wordpress.com/news-sitemap.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/shinpaideshou-news-sitemap.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -330,7 +332,7 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testHebdenbridgetimesArticlesSitemap() throws UnknownFormatException, IOException {
+    public void testHebdenbridgetimesArticlesSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.setStrictNamespace(true);
         parser.enableExtension(Extension.NEWS);
@@ -338,7 +340,7 @@ public class SiteMapParserExtensionTest {
         parser.enableExtension(Extension.VIDEO);
         parser.enableExtension(Extension.MOBILE);
 
-        URL url = new URL("http://www.hebdenbridgetimes.co.uk/sitemap-article-2015-18.xml");
+        URL url = new URI("http://www.hebdenbridgetimes.co.uk/sitemap-article-2015-18.xml").toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/hebdenbridgetimes-articles-sitemap.xml", url);
 
         assertEquals(false, asm.isIndex());
@@ -348,13 +350,13 @@ public class SiteMapParserExtensionTest {
     }
 
     @Test
-    public void testPageMapSitemap() throws UnknownFormatException, IOException {
+    public void testPageMapSitemap() throws UnknownFormatException, IOException, URISyntaxException {
         SiteMapParser parser = new SiteMapParser();
         parser.setStrictNamespace(true);
         parser.enableExtension(Extension.PAGEMAPS);
 
         String urlStr = "http://www.example.com/pagemaps-sitemap.xml";
-        URL url = new URL(urlStr);
+        URL url = new URI(urlStr).toURL();
         AbstractSiteMap asm = parse(parser, "src/test/resources/sitemaps/extension/pagemaps-sitemap.xml", url);
 
         assertEquals(false, asm.isIndex());

--- a/src/test/java/crawlercommons/sitemaps/extension/ImageAttributesTest.java
+++ b/src/test/java/crawlercommons/sitemaps/extension/ImageAttributesTest.java
@@ -3,7 +3,8 @@ package crawlercommons.sitemaps.extension;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -12,12 +13,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class ImageAttributesTest {
 
     @Test
-    public void testImageAttributesAsMap() throws MalformedURLException {
-        ImageAttributes attributes = new ImageAttributes(new URL("http://example.com/image.jpg"));
+    public void testImageAttributesAsMap() throws MalformedURLException, URISyntaxException {
+        ImageAttributes attributes = new ImageAttributes(new URI("http://example.com/image.jpg").toURL());
         attributes.setCaption("caption");
         attributes.setGeoLocation("kalamazoo");
         attributes.setTitle("Title");
-        attributes.setLicense(new URL("http://example.com/license"));
+        attributes.setLicense(new URI("http://example.com/license").toURL());
         Map<String, String[]> map = attributes.asMap();
 
         assertEquals(attributes.getLoc().toString(), map.get(ImageAttributes.LOC)[0]);

--- a/src/test/java/crawlercommons/sitemaps/extension/LinkAttributesTest.java
+++ b/src/test/java/crawlercommons/sitemaps/extension/LinkAttributesTest.java
@@ -3,7 +3,8 @@ package crawlercommons.sitemaps.extension;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -12,8 +13,8 @@ import static org.junit.jupiter.api.Assertions.*;
 public class LinkAttributesTest {
 
     @Test
-    public void testLinkAttributesAsMap() throws MalformedURLException {
-        LinkAttributes attributes = new LinkAttributes(new URL("http://www.example.com/deutsch/"));
+    public void testLinkAttributesAsMap() throws MalformedURLException, URISyntaxException {
+        LinkAttributes attributes = new LinkAttributes(new URI("http://www.example.com/deutsch/").toURL());
         attributes.setParams(new HashMap<String, String>() {
             {
                 put("rel", "alternate");

--- a/src/test/java/crawlercommons/sitemaps/extension/MobileAttributesTest.java
+++ b/src/test/java/crawlercommons/sitemaps/extension/MobileAttributesTest.java
@@ -2,7 +2,6 @@ package crawlercommons.sitemaps.extension;
 
 import org.junit.jupiter.api.Test;
 
-import java.net.MalformedURLException;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -10,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class MobileAttributesTest {
 
     @Test
-    public void testMobileAttributesAsMap() throws MalformedURLException {
+    public void testMobileAttributesAsMap() {
         MobileAttributes attributes = new MobileAttributes();
         Map<String, String[]> map = attributes.asMap();
 

--- a/src/test/java/crawlercommons/sitemaps/extension/VideoAttributesTest.java
+++ b/src/test/java/crawlercommons/sitemaps/extension/VideoAttributesTest.java
@@ -3,7 +3,8 @@ package crawlercommons.sitemaps.extension;
 import org.junit.jupiter.api.Test;
 
 import java.net.MalformedURLException;
-import java.net.URL;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Map;
@@ -15,9 +16,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class VideoAttributesTest {
 
     @Test
-    public void testVideoAttributesAsMap() throws MalformedURLException {
-        VideoAttributes attributes = new VideoAttributes(new URL("http://www.example.com/thumbs/123.jpg"), "Grilling steaks for summer",
-                "Alkis shows you how to get perfectly done steaks every time", new URL("http://www.example.com/video123.flv"), new URL("http://www.example.com/videoplayer.swf?video=123"));
+    public void testVideoAttributesAsMap() throws MalformedURLException, URISyntaxException {
+        VideoAttributes attributes = new VideoAttributes(new URI("http://www.example.com/thumbs/123.jpg").toURL(), "Grilling steaks for summer",
+                "Alkis shows you how to get perfectly done steaks every time", new URI("http://www.example.com/video123.flv").toURL(), new URI("http://www.example.com/videoplayer.swf?video=123").toURL());
         attributes.setDuration(600);
         ZonedDateTime dt = ZonedDateTime.parse("2009-11-05T19:20:30+08:00");
         attributes.setExpirationDate(dt);
@@ -29,12 +30,12 @@ public class VideoAttributesTest {
         attributes.setFamilyFriendly(true);
         attributes.setTags(new String[] { "sample_tag1", "sample_tag2" });
         attributes.setAllowedCountries(new String[] { "IE", "GB", "US", "CA" });
-        attributes.setGalleryLoc(new URL("http://cooking.example.com"));
+        attributes.setGalleryLoc(new URI("http://cooking.example.com").toURL());
         attributes.setGalleryTitle("Cooking Videos");
         attributes.setPrices(new VideoAttributes.VideoPrice[] { new VideoAttributes.VideoPrice("EUR", 1.99f, VideoAttributes.VideoPriceType.own) });
         attributes.setRequiresSubscription(true);
         attributes.setUploader("GrillyMcGrillerson");
-        attributes.setUploaderInfo(new URL("http://www.example.com/users/grillymcgrillerson"));
+        attributes.setUploaderInfo(new URI("http://www.example.com/users/grillymcgrillerson").toURL());
         attributes.setLive(false);
         attributes.setDuration(54321);
         Map<String, String[]> map = attributes.asMap();

--- a/src/test/resources/forbidden-apis-signatures.txt
+++ b/src/test/resources/forbidden-apis-signatures.txt
@@ -1,2 +1,8 @@
 java.net.URL#equals(java.lang.Object) @ may trigger a DNS lookup to resolve the host part
 java.net.URL#hashCode()               @ may trigger a DNS lookup to resolve the host part
+java.net.URL#<init>(java.lang.String) @ deprecated since Java 20
+java.net.URL#<init>(java.lang.String, java.lang.String, java.lang.String) @ deprecated since Java 20
+java.net.URL#<init>(java.lang.String, java.lang.String, int, java.lang.String) @ deprecated since Java 20
+java.net.URL#<init>(java.lang.String, java.lang.String, int, java.lang.String, java.net.URLStreamHandler) @ deprecated since Java 20
+java.net.URL#<init>(java.net.URL, java.lang.String) @ deprecated since Java 20
+java.net.URL#<init>(java.net.URL, java.lang.String, java.net.URLStreamHandler) @ deprecated since Java 20


### PR DESCRIPTION
See #522.
- Replace the deprecated URL constructors in unit tests
- Forbid deprecated URL constructors per forbiddenAPIs