### PR TITLE
#551 – Support IDNA2008 Unicode domains by using ALLOW_UNASSIGNED in IDN methods within TldFinder / Normalizer.

### DIFF
--- a/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
+++ b/src/main/java/crawlercommons/domains/EffectiveTldFinder.java
@@ -16,6 +16,7 @@
 
 package crawlercommons.domains;
 
+import static java.net.IDN.ALLOW_UNASSIGNED;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedReader;
@@ -404,7 +405,7 @@ public class EffectiveTldFinder {
         String domainSegment = hostname.substring(start, etldStartPos);
         if (!EffectiveTLD.isAscii(domainSegment)) {
             try {
-                IDN.toASCII(domainSegment);
+                IDN.toASCII(domainSegment, ALLOW_UNASSIGNED);
             } catch (IllegalArgumentException e) {
                 // not a valid IDN segment,
                 // includes check for max. length (63 chars)
@@ -613,7 +614,7 @@ public class EffectiveTldFinder {
             String[] var = new String[parts.length];
             for (int i = 0; i < parts.length; i++) {
                 if (!isAscii(parts[i])) {
-                    var[i] = IDN.toASCII(parts[i]);
+                    var[i] = IDN.toASCII(parts[i], ALLOW_UNASSIGNED);
                 }
             }
             for (int i = 0; i < parts.length; i++) {
@@ -653,7 +654,7 @@ public class EffectiveTldFinder {
             if (isAscii(str)) {
                 return str.toLowerCase(Locale.ROOT);
             }
-            return IDN.toASCII(str);
+            return IDN.toASCII(str, ALLOW_UNASSIGNED);
         }
 
         private static boolean isAscii(String str) {

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -16,6 +16,7 @@
 
 package crawlercommons.filters.basic;
 
+import static java.net.IDN.ALLOW_UNASSIGNED;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import java.io.BufferedReader;
@@ -647,9 +648,9 @@ public class BasicURLNormalizer extends URLFilter {
              * (non-ASCII dot-separated segment) is longer than 256 characters,
              * cf. https://bugs.openjdk.java.net/browse/JDK-6806873
              */
-            host = IDN.toASCII(host);
+            host = IDN.toASCII(host, ALLOW_UNASSIGNED);
         } else if (this.idnNormalization == IdnNormalization.UNICODE && host.contains("xn--")) {
-            host = IDN.toUnicode(host);
+            host = IDN.toUnicode(host, ALLOW_UNASSIGNED);
         }
 
         /* 4. trim a trailing dot */


### PR DESCRIPTION
We actually didn't use the constant at all.