### PR TITLE
Support LLM-Policy entry in robots.txt

### DIFF
--- a/src/main/java/crawlercommons/robots/BaseRobotRules.java
+++ b/src/main/java/crawlercommons/robots/BaseRobotRules.java
@@ -19,8 +19,11 @@ package crawlercommons.robots;
 import java.io.Serializable;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.EnumMap;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Result from parsing a single robots.txt file – a set of allow/disallow rules
@@ -46,6 +49,7 @@ public abstract class BaseRobotRules implements Serializable {
     private boolean _deferVisits = false;
     private boolean _matchedWildcard = false;
     private LinkedHashSet<String> _sitemaps;
+    private EnumMap<RobotsExtension, RobotsExtensionData> _extensions;
 
     public BaseRobotRules() {
         _sitemaps = new LinkedHashSet<>();
@@ -114,6 +118,74 @@ public abstract class BaseRobotRules implements Serializable {
         return new ArrayList<>(_sitemaps);
     }
 
+    /**
+     * Get extension data for a specific robots.txt extension directive.
+     *
+     * @param extension
+     *            the extension to query
+     * @return the extension data, or {@code null} if no data was collected for
+     *         this extension
+     */
+    public RobotsExtensionData getExtensionData(RobotsExtension extension) {
+        if (_extensions == null) {
+            return null;
+        }
+        return _extensions.get(extension);
+    }
+
+    /**
+     * Get all collected extension data.
+     *
+     * @return an unmodifiable map of extension data, or an empty map if no
+     *         extensions were collected. Never {@code null}.
+     */
+    public Map<RobotsExtension, RobotsExtensionData> getExtensions() {
+        if (_extensions == null) {
+            return Collections.emptyMap();
+        }
+        return Collections.unmodifiableMap(_extensions);
+    }
+
+    /**
+     * Add a value for a robots.txt extension directive. The extension data
+     * container is lazily created on first use.
+     *
+     * @param extension
+     *            the extension directive
+     * @param value
+     *            the directive value (text after the colon)
+     */
+    public void addExtensionValue(RobotsExtension extension, String value) {
+        if (_extensions == null) {
+            _extensions = new EnumMap<>(RobotsExtension.class);
+        }
+        SimpleRobotsExtensionData data = (SimpleRobotsExtensionData) _extensions.get(extension);
+        if (data == null) {
+            data = new SimpleRobotsExtensionData(extension);
+            _extensions.put(extension, data);
+        }
+        data.addValue(value);
+    }
+
+    /**
+     * Clear all extension data for a specific extension.
+     *
+     * @param extension
+     *            the extension to clear
+     */
+    public void clearExtensionData(RobotsExtension extension) {
+        if (_extensions != null) {
+            _extensions.remove(extension);
+        }
+    }
+
+    /**
+     * Clear all collected extension data.
+     */
+    public void clearAllExtensionData() {
+        _extensions = null;
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -121,6 +193,7 @@ public abstract class BaseRobotRules implements Serializable {
         result = prime * result + (int) (_crawlDelay ^ (_crawlDelay >>> 32));
         result = prime * result + (_deferVisits ? 1231 : 1237);
         result = prime * result + ((_sitemaps == null) ? 0 : _sitemaps.hashCode());
+        result = prime * result + ((_extensions == null) ? 0 : _extensions.hashCode());
         return result;
     }
 
@@ -141,6 +214,11 @@ public abstract class BaseRobotRules implements Serializable {
             if (other._sitemaps != null)
                 return false;
         } else if (!_sitemaps.equals(other._sitemaps))
+            return false;
+        if (_extensions == null) {
+            if (other._extensions != null)
+                return false;
+        } else if (!_extensions.equals(other._extensions))
             return false;
         return true;
     }
@@ -169,6 +247,21 @@ public abstract class BaseRobotRules implements Serializable {
             int numOfSitemapsToShow = Math.min(nSitemaps, 10);
             for (int i = 0; i < numOfSitemapsToShow; i++) {
                 sb.append(sitemaps.get(i)).append("\n");
+            }
+        }
+
+        Map<RobotsExtension, RobotsExtensionData> extensions = getExtensions();
+        if (!extensions.isEmpty()) {
+            sb.append(" - extensions:\n");
+            for (Map.Entry<RobotsExtension, RobotsExtensionData> entry : extensions.entrySet()) {
+                sb.append("   ").append(entry.getKey().getDirectiveName()).append(": ");
+                List<String> values = entry.getValue().getValues();
+                if (values.size() == 1) {
+                    sb.append(values.get(0));
+                } else {
+                    sb.append(values);
+                }
+                sb.append('\n');
             }
         }
 

--- a/src/main/java/crawlercommons/robots/RobotsExtension.java
+++ b/src/main/java/crawlercommons/robots/RobotsExtension.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2016 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.robots;
+
+/**
+ * Known robots.txt extension directives that can be optionally enabled in
+ * {@link SimpleRobotRulesParser}.
+ *
+ * <p>
+ * Each constant carries:
+ * </p>
+ * <ul>
+ * <li>{@link #getDirectiveName()} &ndash; the canonical lower-case directive
+ * name as it appears in a robots.txt file (e.g. {@code "llm-policy"})</li>
+ * <li>{@link #isPerGroup()} &ndash; whether the directive is scoped to a
+ * specific user-agent group ({@code true}) or applies globally to the entire
+ * robots.txt file ({@code false})</li>
+ * <li>{@link #getAliases()} &ndash; optional alternative spellings that should
+ * also be recognized</li>
+ * </ul>
+ *
+ * <p>
+ * Extensions are opt-in: they are only parsed and stored when explicitly enabled
+ * via {@link SimpleRobotRulesParser#enableExtension(RobotsExtension)},
+ * {@link SimpleRobotRulesParser#enableExtensions(java.util.Collection)}, or
+ * {@link SimpleRobotRulesParser#enableAllExtensions()}.
+ * </p>
+ *
+ * @see SimpleRobotRulesParser
+ * @see BaseRobotRules#getExtensionData(RobotsExtension)
+ */
+public enum RobotsExtension {
+
+    /**
+     * LLM-Policy directive, used to point to an llms.txt file or similar
+     * policy document for AI/LLM crawlers.
+     */
+    LLM_POLICY("llm-policy", false),
+
+    /**
+     * Yandex Clean-Param directive, used to indicate URL parameters that should
+     * be ignored when determining page uniqueness. See
+     * <a href="https://yandex.com/support/webmaster/en/robot-workings/clean-param">
+     * Yandex documentation</a>.
+     */
+    CLEAN_PARAM("clean-param", true),
+
+    /**
+     * Cloudflare Content-Signals policy directive, an extension for content
+     * governance rules (e.g. AI training data usage, attribution). See
+     * <a href="https://blog.cloudflare.com/content-signals-policy">Cloudflare
+     * blog post</a>.
+     */
+    CONTENT_SIGNALS("content-signals", false),
+
+    /**
+     * The &quot;Host&quot; directive was used by Yandex to indicate the main or
+     * canonical host of a set of mirrored web sites.
+     */
+    HOST("host", false),
+
+    /**
+     * Google extension: Noindex directive to prevent indexing of specific URLs.
+     */
+    NO_INDEX("no-index", true, "noindex"),
+
+    /**
+     * Request-Rate directive, used to specify the maximum crawl rate.
+     */
+    REQUEST_RATE("request-rate", true),
+
+    /**
+     * Visit-Time directive, used to specify preferred crawling time windows.
+     */
+    VISIT_TIME("visit-time", true),
+
+    /**
+     * Robot-Version directive, used to indicate the robots.txt specification
+     * version.
+     */
+    ROBOT_VERSION("robot-version", true),
+
+    /**
+     * Comment directive, used to provide human-readable comments about the
+     * rules in a user-agent group.
+     */
+    COMMENT("comment", true);
+
+    private final String _directiveName;
+    private final boolean _perGroup;
+    private final String[] _aliases;
+
+    RobotsExtension(String directiveName, boolean perGroup, String... aliases) {
+        _directiveName = directiveName;
+        _perGroup = perGroup;
+        _aliases = aliases;
+    }
+
+    /**
+     * @return the canonical lower-case directive name as it appears in a
+     *         robots.txt file (e.g. {@code "llm-policy"})
+     */
+    public String getDirectiveName() {
+        return _directiveName;
+    }
+
+    /**
+     * @return {@code true} if this directive is scoped to a specific user-agent
+     *         group, {@code false} if it applies globally to the entire
+     *         robots.txt file
+     */
+    public boolean isPerGroup() {
+        return _perGroup;
+    }
+
+    /**
+     * @return {@code true} if this directive applies globally, not scoped to
+     *         any particular user-agent group
+     */
+    public boolean isGlobal() {
+        return !_perGroup;
+    }
+
+    /**
+     * @return alternative spellings / aliases for this directive (may be empty)
+     */
+    public String[] getAliases() {
+        return _aliases;
+    }
+}

--- a/src/main/java/crawlercommons/robots/RobotsExtension.java
+++ b/src/main/java/crawlercommons/robots/RobotsExtension.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Crawler-Commons
+ * Copyright 2026 Crawler-Commons
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/crawlercommons/robots/RobotsExtensionData.java
+++ b/src/main/java/crawlercommons/robots/RobotsExtensionData.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2016 Crawler-Commons
+ * Copyright 2026 Crawler-Commons
  * 
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/crawlercommons/robots/RobotsExtensionData.java
+++ b/src/main/java/crawlercommons/robots/RobotsExtensionData.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright 2016 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.robots;
+
+import java.io.Serializable;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Container for data collected from a robots.txt extension directive.
+ *
+ * <p>
+ * The default implementation ({@link SimpleRobotsExtensionData}) stores raw
+ * string values as they appear in the robots.txt file. Consumers that need
+ * richer typed data for specific extensions (e.g., parsing structured
+ * Content-Signals fields) can provide their own implementations.
+ * </p>
+ *
+ * @see RobotsExtension
+ * @see BaseRobotRules#getExtensionData(RobotsExtension)
+ */
+public interface RobotsExtensionData extends Serializable {
+
+    /**
+     * @return the extension this data belongs to
+     */
+    RobotsExtension getExtension();
+
+    /**
+     * @return the raw string values collected for this extension directive,
+     *         one entry per occurrence in the robots.txt file
+     */
+    List<String> getValues();
+
+    /**
+     * @return a map representation of this extension data, suitable for generic
+     *         serialization. The map key is the directive name, and the value is
+     *         an array of the raw string values.
+     */
+    Map<String, String[]> asMap();
+}

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -513,8 +513,8 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     private int _maxWarnings;
     private long _maxCrawlDelay;
     private boolean _exactUserAgentMatching;
-    private Set<RobotsExtension> _enabledExtensions = Collections.emptySet();
-    private Map<String, RobotsExtension> _extensionDirectiveLookup = Collections.emptyMap();
+    private volatile Set<RobotsExtension> _enabledExtensions = Collections.emptySet();
+    private volatile Map<String, RobotsExtension> _extensionDirectiveLookup = Collections.emptyMap();
 
     /**
      * Mapping from {@link RobotDirective} enum values to their corresponding

--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -28,6 +28,8 @@ import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
 import java.util.Locale;
@@ -511,6 +513,24 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     private int _maxWarnings;
     private long _maxCrawlDelay;
     private boolean _exactUserAgentMatching;
+    private Set<RobotsExtension> _enabledExtensions = Collections.emptySet();
+    private Map<String, RobotsExtension> _extensionDirectiveLookup = Collections.emptyMap();
+
+    /**
+     * Mapping from {@link RobotDirective} enum values to their corresponding
+     * {@link RobotsExtension}. This allows the parser to capture values for
+     * directives already known to the {@link RobotDirective} enum when the
+     * matching extension is enabled.
+     */
+    private static final Map<RobotDirective, RobotsExtension> DIRECTIVE_TO_EXTENSION = new HashMap<>();
+    static {
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.HOST, RobotsExtension.HOST);
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.NO_INDEX, RobotsExtension.NO_INDEX);
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.REQUEST_RATE, RobotsExtension.REQUEST_RATE);
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.VISIT_TIME, RobotsExtension.VISIT_TIME);
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.ROBOT_VERSION, RobotsExtension.ROBOT_VERSION);
+        DIRECTIVE_TO_EXTENSION.put(RobotDirective.COMMENT, RobotsExtension.COMMENT);
+    }
 
     public SimpleRobotRulesParser() {
         this(DEFAULT_MAX_CRAWL_DELAY, DEFAULT_MAX_WARNINGS);
@@ -831,15 +851,19 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                     break;
 
                 case UNKNOWN:
-                reportWarning(parseState, "Unknown directive in robots.txt file: {}", line);
+                if (!handlePossibleExtension(parseState, line)) {
+                    reportWarning(parseState, "Unknown directive in robots.txt file: {}", line);
+                }
                     break;
 
                 case MISSING:
-                reportWarning(parseState, "Unknown line in robots.txt file (size {}): {}", content.length, line);
+                if (!handlePossibleExtension(parseState, line)) {
+                    reportWarning(parseState, "Unknown line in robots.txt file (size {}): {}", content.length, line);
+                }
                     break;
 
                 default:
-                    // All others we just ignore
+                    handleKnownDirectiveExtension(parseState, token);
                     break;
             }
         }
@@ -1172,6 +1196,74 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     }
 
     /**
+     * Try to handle a line as an enabled extension directive. Called when the
+     * line was not recognized by the standard {@link RobotDirective} tokenizer.
+     *
+     * @param state
+     *            current parsing state
+     * @param line
+     *            the raw robots.txt line
+     * @return {@code true} if the line was handled as an extension directive
+     */
+    private boolean handlePossibleExtension(ParseState state, String line) {
+        if (_extensionDirectiveLookup.isEmpty()) {
+            return false;
+        }
+        String lowerLine = line.toLowerCase(Locale.ROOT);
+        for (Map.Entry<String, RobotsExtension> entry : _extensionDirectiveLookup.entrySet()) {
+            String prefix = entry.getKey();
+            if (lowerLine.startsWith(prefix)) {
+                String rest = line.substring(prefix.length());
+                Matcher m = COLON_DIRECTIVE_DELIMITER.matcher(rest);
+                if (m.matches()) {
+                    handleExtensionDirective(state, entry.getValue(), m.group(1).trim());
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Capture the value of a {@link RobotDirective} that has a corresponding
+     * {@link RobotsExtension} when that extension is enabled. This handles
+     * directives like HOST, NO_INDEX, REQUEST_RATE, etc. that are already
+     * recognized by the tokenizer but whose values were previously discarded.
+     *
+     * @param state
+     *            current parsing state
+     * @param token
+     *            data for directive
+     */
+    private void handleKnownDirectiveExtension(ParseState state, RobotToken token) {
+        RobotsExtension ext = DIRECTIVE_TO_EXTENSION.get(token.getDirective());
+        if (ext != null && _enabledExtensions.contains(ext)) {
+            handleExtensionDirective(state, ext, token.getData());
+        }
+    }
+
+    /**
+     * Store an extension directive value in the current rules, respecting
+     * per-group vs. global scoping.
+     *
+     * @param state
+     *            current parsing state
+     * @param extension
+     *            the robots.txt extension
+     * @param value
+     *            the directive value (text after the colon, trimmed)
+     */
+    private void handleExtensionDirective(ParseState state, RobotsExtension extension, String value) {
+        if (extension.isPerGroup()) {
+            if (state.isAddingRules()) {
+                state.getRobotRules().addExtensionValue(extension, value);
+            }
+        } else {
+            state.getRobotRules().addExtensionValue(extension, value);
+        }
+    }
+
+    /**
      * Get the number of warnings due to invalid rules/lines in the latest
      * processed robots.txt file (see
      * {@link #parseContent(String, byte[], String, String)}.
@@ -1266,6 +1358,63 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
      */
     public boolean isExactUserAgentMatching() {
         return _exactUserAgentMatching;
+    }
+
+    /**
+     * Enable a single robots.txt extension directive. When enabled, the
+     * parser will capture the directive's value(s) in the returned
+     * {@link SimpleRobotRules} and suppress any &quot;unknown directive&quot;
+     * warnings for that directive.
+     *
+     * @param extension
+     *            the extension to enable
+     * @see #enableExtensions(Collection)
+     * @see #enableAllExtensions()
+     */
+    public void enableExtension(RobotsExtension extension) {
+        enableExtensions(EnumSet.of(extension));
+    }
+
+    /**
+     * Enable a collection of robots.txt extension directives. When enabled,
+     * the parser will capture each directive's value(s) in the returned
+     * {@link SimpleRobotRules} and suppress any &quot;unknown directive&quot;
+     * warnings for those directives.
+     *
+     * @param extensions
+     *            the extensions to enable
+     * @see #enableExtension(RobotsExtension)
+     * @see #enableAllExtensions()
+     */
+    public void enableExtensions(Collection<RobotsExtension> extensions) {
+        _enabledExtensions = EnumSet.copyOf(extensions);
+        _extensionDirectiveLookup = new HashMap<>();
+        for (RobotsExtension ext : _enabledExtensions) {
+            _extensionDirectiveLookup.put(ext.getDirectiveName(), ext);
+            for (String alias : ext.getAliases()) {
+                _extensionDirectiveLookup.put(alias, ext);
+            }
+        }
+    }
+
+    /**
+     * Enable all known robots.txt extension directives. This is a convenience
+     * method equivalent to
+     * {@code enableExtensions(EnumSet.allOf(RobotsExtension.class))}.
+     *
+     * @see #enableExtension(RobotsExtension)
+     * @see #enableExtensions(Collection)
+     */
+    public void enableAllExtensions() {
+        enableExtensions(EnumSet.allOf(RobotsExtension.class));
+    }
+
+    /**
+     * @return the set of currently enabled extensions (may be empty, never
+     *         {@code null})
+     */
+    public Set<RobotsExtension> getEnabledExtensions() {
+        return Collections.unmodifiableSet(_enabledExtensions);
     }
 
     public static void main(String[] args) throws IOException, URISyntaxException {

--- a/src/main/java/crawlercommons/robots/SimpleRobotsExtensionData.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotsExtensionData.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2016 Crawler-Commons
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.robots;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Default implementation of {@link RobotsExtensionData} that stores raw string
+ * values as they appear in the robots.txt file.
+ *
+ * <p>
+ * Each occurrence of an extension directive in the robots.txt file adds one
+ * value to the list. This is compact: a single {@link ArrayList} per extension
+ * per robots.txt.
+ * </p>
+ */
+@SuppressWarnings("serial")
+public class SimpleRobotsExtensionData implements RobotsExtensionData {
+
+    private final RobotsExtension _extension;
+    private final List<String> _values;
+
+    public SimpleRobotsExtensionData(RobotsExtension extension) {
+        _extension = extension;
+        _values = new ArrayList<>();
+    }
+
+    @Override
+    public RobotsExtension getExtension() {
+        return _extension;
+    }
+
+    @Override
+    public List<String> getValues() {
+        return Collections.unmodifiableList(_values);
+    }
+
+    /**
+     * Add a value collected from a robots.txt directive line.
+     *
+     * @param value
+     *            the directive value (text after the colon)
+     */
+    public void addValue(String value) {
+        _values.add(value);
+    }
+
+    /** Clear all stored values. */
+    public void clearValues() {
+        _values.clear();
+    }
+
+    @Override
+    public Map<String, String[]> asMap() {
+        return Map.of(_extension.getDirectiveName(), _values.toArray(new String[0]));
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + _extension.hashCode();
+        result = prime * result + _values.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        SimpleRobotsExtensionData other = (SimpleRobotsExtensionData) obj;
+        if (_extension != other._extension)
+            return false;
+        return _values.equals(other._values);
+    }
+
+    @Override
+    public String toString() {
+        return _extension.getDirectiveName() + ": " + _values;
+    }
+}

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1418,6 +1418,307 @@ public class SimpleRobotRulesParserTest {
         assertTrue(rules2.isAllowed("https://www.example.com/home"));
     }
 
+    // --- Robots.txt extension API tests ---
+
+    @Test
+    void testExtensionLlmPolicyEnabled() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt" + CRLF //
+                        + "Sitemap: /sitemap.xml";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(data, "LLM-Policy extension data should be present");
+        assertEquals(1, data.getValues().size());
+        assertEquals("/llms.txt", data.getValues().get(0));
+        assertEquals(0, robotParser.getNumWarnings(), "No warnings expected when extension is enabled");
+        assertTrue(rules.isAllowed("http://domain.com/anypage.html"));
+    }
+
+    @Test
+    void testExtensionLlmPolicyDisabled() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        assertNull(rules.getExtensionData(RobotsExtension.LLM_POLICY), "LLM-Policy should not be stored when not enabled");
+        assertTrue(rules.getExtensions().isEmpty());
+        assertEquals(1, robotParser.getNumWarnings(), "Warning expected for unrecognized directive");
+    }
+
+    @Test
+    void testExtensionGlobalNotScopedToGroup() {
+        final String robotsTxt = "User-agent: mybot" + CRLF //
+                        + "Disallow: /private/" + CRLF //
+                        + "LLM-Policy: /llms.txt" + CRLF //
+                        + CRLF //
+                        + "User-agent: *" + CRLF //
+                        + "Allow: /";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(data, "Global extension should be captured regardless of user-agent matching");
+        assertEquals("/llms.txt", data.getValues().get(0));
+    }
+
+    @Test
+    void testExtensionPerGroupOnlyWhenMatched() {
+        final String robotsTxt = "User-agent: mybot" + CRLF //
+                        + "Disallow: /private/" + CRLF //
+                        + "Request-rate: 10/1m" + CRLF //
+                        + CRLF //
+                        + "User-agent: *" + CRLF //
+                        + "Allow: /";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.REQUEST_RATE);
+
+        // Parse as "otherbot" which matches only the wildcard group
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of("otherbot"));
+        assertNull(rules.getExtensionData(RobotsExtension.REQUEST_RATE),
+                        "Per-group extension should not be captured for unmatched group");
+
+        // Parse as "mybot" which matches the specific group
+        SimpleRobotRules rules2 = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of("mybot"));
+        RobotsExtensionData data = rules2.getExtensionData(RobotsExtension.REQUEST_RATE);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("10/1m", data.getValues().get(0));
+    }
+
+    @Test
+    void testExtensionMultipleValues() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt" + CRLF //
+                        + "LLM-Policy: /ai-policy.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(data);
+        assertEquals(2, data.getValues().size());
+        assertEquals("/llms.txt", data.getValues().get(0));
+        assertEquals("/ai-policy.txt", data.getValues().get(1));
+    }
+
+    @Test
+    void testEnableAllExtensions() throws Exception {
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableAllExtensions();
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL,
+                        readFile("/robots/extension-robots.txt"), "text/plain", Set.of("mybot"));
+
+        assertEquals(0, robotParser.getNumWarnings(), "No warnings expected when all extensions are enabled");
+
+        // Global extensions
+        RobotsExtensionData llmPolicy = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(llmPolicy);
+        assertEquals("/llms.txt", llmPolicy.getValues().get(0));
+
+        RobotsExtensionData contentSignals = rules.getExtensionData(RobotsExtension.CONTENT_SIGNALS);
+        assertNotNull(contentSignals);
+        assertEquals("/content-signals.json", contentSignals.getValues().get(0));
+
+        RobotsExtensionData host = rules.getExtensionData(RobotsExtension.HOST);
+        assertNotNull(host);
+        assertEquals("www.example.com", host.getValues().get(0));
+
+        // Per-group extensions (matched "mybot" group)
+        RobotsExtensionData requestRate = rules.getExtensionData(RobotsExtension.REQUEST_RATE);
+        assertNotNull(requestRate);
+        assertEquals("10/1m", requestRate.getValues().get(0));
+
+        RobotsExtensionData visitTime = rules.getExtensionData(RobotsExtension.VISIT_TIME);
+        assertNotNull(visitTime);
+        assertEquals("0200-0600", visitTime.getValues().get(0));
+
+        RobotsExtensionData comment = rules.getExtensionData(RobotsExtension.COMMENT);
+        assertNotNull(comment);
+        assertEquals("only crawl at night", comment.getValues().get(0));
+
+        // Core rules still work
+        assertFalse(rules.isAllowed("http://domain.com/private/page.html"));
+        assertTrue(rules.isAllowed("http://domain.com/public/page.html"));
+    }
+
+    @Test
+    void testEnableAllExtensionsWildcardAgent() throws Exception {
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableAllExtensions();
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL,
+                        readFile("/robots/extension-robots.txt"), "text/plain", Set.of());
+
+        // When matching wildcard, per-group extensions from specific groups
+        // should NOT be included
+        assertNull(rules.getExtensionData(RobotsExtension.VISIT_TIME),
+                        "Per-group extensions from non-matching groups should not be present");
+
+        // Global extensions should always be present
+        assertNotNull(rules.getExtensionData(RobotsExtension.LLM_POLICY));
+        assertNotNull(rules.getExtensionData(RobotsExtension.HOST));
+    }
+
+    @Test
+    void testExtensionDoesNotAffectCoreRules() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Disallow: /private/" + CRLF //
+                        + "Allow: /private/public.html" + CRLF //
+                        + "LLM-Policy: /llms.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        assertFalse(rules.isAllowed("http://domain.com/private/secret.html"));
+        assertTrue(rules.isAllowed("http://domain.com/private/public.html"));
+        assertTrue(rules.isAllowed("http://domain.com/other.html"));
+
+        assertNotNull(rules.getExtensionData(RobotsExtension.LLM_POLICY));
+    }
+
+    @Test
+    void testExtensionDataInToString() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        String str = rules.toString();
+        assertTrue(str.contains("llm-policy"), "toString should include extension directive name");
+        assertTrue(str.contains("/llms.txt"), "toString should include extension value");
+    }
+
+    @Test
+    void testExtensionAsMap() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt" + CRLF //
+                        + "LLM-Policy: /ai-policy.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(data);
+        Map<String, String[]> map = data.asMap();
+        assertTrue(map.containsKey("llm-policy"));
+        assertArrayEquals(new String[] { "/llms.txt", "/ai-policy.txt" }, map.get("llm-policy"));
+    }
+
+    @Test
+    void testExtensionCaseInsensitiveDirective() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "llm-policy: /lower.txt" + CRLF //
+                        + "LLM-POLICY: /upper.txt" + CRLF //
+                        + "Llm-Policy: /mixed.txt";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.LLM_POLICY);
+        assertNotNull(data);
+        assertEquals(3, data.getValues().size());
+    }
+
+    @Test
+    void testExtensionNoIndexPerGroup() {
+        final String robotsTxt = "User-agent: mybot" + CRLF //
+                        + "Disallow: /private/" + CRLF //
+                        + "Noindex: /secret/" + CRLF //
+                        + CRLF //
+                        + "User-agent: *" + CRLF //
+                        + "Allow: /";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.NO_INDEX);
+
+        // "mybot" matches the specific group
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of("mybot"));
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.NO_INDEX);
+        assertNotNull(data, "Noindex should be captured via alias");
+        assertEquals("/secret/", data.getValues().get(0));
+    }
+
+    @Test
+    void testGetEnabledExtensions() {
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        assertTrue(robotParser.getEnabledExtensions().isEmpty());
+
+        robotParser.enableExtension(RobotsExtension.LLM_POLICY);
+        assertEquals(1, robotParser.getEnabledExtensions().size());
+        assertTrue(robotParser.getEnabledExtensions().contains(RobotsExtension.LLM_POLICY));
+
+        robotParser.enableAllExtensions();
+        assertEquals(RobotsExtension.values().length, robotParser.getEnabledExtensions().size());
+    }
+
+    @Test
+    void testExtensionEqualsAndHashCode() {
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Allow: /" + CRLF //
+                        + "LLM-Policy: /llms.txt";
+
+        SimpleRobotRulesParser parser1 = new SimpleRobotRulesParser();
+        parser1.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules1 = parser1.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        SimpleRobotRulesParser parser2 = new SimpleRobotRulesParser();
+        parser2.enableExtension(RobotsExtension.LLM_POLICY);
+        SimpleRobotRules rules2 = parser2.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        assertEquals(rules1, rules2);
+        assertEquals(rules1.hashCode(), rules2.hashCode());
+
+        // Without extensions enabled, rules should differ
+        SimpleRobotRulesParser parser3 = new SimpleRobotRulesParser();
+        SimpleRobotRules rules3 = parser3.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of());
+
+        assertNotEquals(rules1, rules3);
+    }
+
+    @Test
+    void testExtendedStandardWithExtensionsEnabled() throws Exception {
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableAllExtensions();
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL,
+                        readFile("/robots/extended-standard-robots.txt"), "text/plain", Set.of("bot1"));
+        assertEquals(0, robotParser.getNumWarnings(), "Zero warnings with extended directives");
+
+        RobotsExtensionData requestRate = rules.getExtensionData(RobotsExtension.REQUEST_RATE);
+        assertNotNull(requestRate, "Request-rate should be captured when enabled");
+        assertEquals("30/1m", requestRate.getValues().get(0));
+
+        RobotsExtensionData visitTime = rules.getExtensionData(RobotsExtension.VISIT_TIME);
+        assertNotNull(visitTime);
+        assertEquals("0100-0600", visitTime.getValues().get(0));
+
+        RobotsExtensionData robotVersion = rules.getExtensionData(RobotsExtension.ROBOT_VERSION);
+        assertNotNull(robotVersion);
+        assertEquals("2.0", robotVersion.getValues().get(0));
+
+        RobotsExtensionData comment = rules.getExtensionData(RobotsExtension.COMMENT);
+        assertNotNull(comment);
+        assertEquals("This is a comment about bot1", comment.getValues().get(0));
+    }
+
     private byte[] readFile(String filename) throws Exception {
         byte[] bigBuffer = new byte[100000];
         InputStream is = SimpleRobotRulesParserTest.class.getResourceAsStream(filename);

--- a/src/test/resources/robots/extension-robots.txt
+++ b/src/test/resources/robots/extension-robots.txt
@@ -1,0 +1,18 @@
+User-agent: *
+Allow: /
+LLM-Policy: /llms.txt
+Sitemap: /sitemap.xml
+Content-Signals: /content-signals.json
+
+User-agent: mybot
+Disallow: /private/
+Request-rate: 10/1m
+Visit-time: 0200-0600
+Comment: only crawl at night
+No-index: /secret/
+
+User-agent: otherbot
+Disallow: /admin/
+Request-rate: 5/1m
+
+Host: www.example.com


### PR DESCRIPTION
Proposed patch for https://github.com/crawler-commons/crawler-commons/issues/564

This PR adds a pluggable extension API to the crawler-commons robots.txt parser, enabling opt-in support for non-standard directives such as LLM-Policy, Clean-Param, Content-Signals, and others. The design follows the same philosophy as the existing sitemap Extension API but is adapted to the simpler, line-oriented nature of robots.txt.

Backwards compatibility:
* No breaking changes. By default no extensions are enabled -- behavior is identical to before.
* The `_extensions` map in `BaseRobotRules` stays `null` until a value is added, so there is _zero memory overhead_ for crawlers that don't use extensions.
Existing `getCrawlDelay()` / `getSitemaps()` methods are unchanged; they remain part of the core contract.

Example usage:
```java
SimpleRobotRulesParser parser = new SimpleRobotRulesParser();

// Enable a single extension
parser.enableExtension(RobotsExtension.LLM_POLICY);

// Enable a specific set of extensions
parser.enableExtensions(EnumSet.of(
    RobotsExtension.LLM_POLICY,
    RobotsExtension.CONTENT_SIGNALS,
    RobotsExtension.REQUEST_RATE
));

// Or enable all known extensions at once
parser.enableAllExtensions();

// Inspect which extensions are currently enabled
Set<RobotsExtension> enabled = parser.getEnabledExtensions();

// Parse as usual -- extension data is collected automatically
SimpleRobotRules rules = parser.parseContent(url, content, contentType, agentNames);

// Access data for a specific extension
RobotsExtensionData llmPolicy = rules.getExtensionData(RobotsExtension.LLM_POLICY);
if (llmPolicy != null) {
    List<String> values = llmPolicy.getValues(); // e.g. ["/llms.txt"]
    Map<String, String[]> map = llmPolicy.asMap(); // {"llm-policy": ["/llms.txt"]}
}

// Access all collected extension data at once
Map<RobotsExtension, RobotsExtensionData> allExtensions = rules.getExtensions();
```