### PR TITLE
Sitemap extension LinkAttributes: allow XHTML namespace URIs with trailing slash

### DIFF
--- a/src/main/java/crawlercommons/sitemaps/Namespace.java
+++ b/src/main/java/crawlercommons/sitemaps/Namespace.java
@@ -73,7 +73,9 @@ public class Namespace {
 
     public static final String[] LINKS = {
                     "http://www.w3.org/1999/xhtml",
-                    "https://www.w3.org/1999/xhtml"
+                    "https://www.w3.org/1999/xhtml",
+                    "http://www.w3.org/1999/xhtml/",
+                    "https://www.w3.org/1999/xhtml/"
     };
 
     public static final String[] PAGEMAPS = {


### PR DESCRIPTION
Sometimes the namespace URIs in sitemaps do not follow strictly the specification, cf. #211 and #487. So far, variants are because of changed version numbers, the URI scheme (`http://` vs `https://`), and also with and without trailing slash (`/`).

In case of the namespace URIs of the extension to enable support for localized links (LinkAttributes), the [spec](https://developers.google.com/search/docs/specialty/international/localized-versions?rd=1#sitemap) requires the namespace defined as follows:
```
xmlns:xhtml="http://www.w3.org/1999/xhtml"
```

Some sitemaps (<https://kpmg.com/tr/tr/sitemap.xml>) add a trailing slash:
```
xmlns:xhtml="http://www.w3.org/1999/xhtml/"
```

This PR adds variant namespace URIs to cover this observed error.