### PR TITLE
Let Dependabot upgrade GitHub workflow actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: weekly
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+    interval: weekly


### PR DESCRIPTION
Several of the GitHub workflow actions use old version, for example, `actions/checkout@v3`. Should tell Dependabot to update if newer versions are available.