### PR TITLE
Add lazy CrawlerURL and URI/CrawlerURL API variants (#556)

### DIFF
--- a/src/main/java/crawlercommons/domains/PaidLevelDomain.java
+++ b/src/main/java/crawlercommons/domains/PaidLevelDomain.java
@@ -16,11 +16,14 @@
 
 package crawlercommons.domains;
 
+import java.net.URI;
 import java.net.URL;
 import java.util.regex.Pattern;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import crawlercommons.url.CrawlerURL;
 
 /**
  * Routines to extract the PLD (paid-level domain, as per the IRLbot paper) from
@@ -69,6 +72,37 @@ public class PaidLevelDomain {
      * @return PLD, e.g. <code>example.co.uk</code>
      */
     public static String getPLD(URL url) {
+        return getPLD(url.getHost());
+    }
+
+    /**
+     * Extract the PLD (paid-level domain) from the URI.
+     *
+     * <p>
+     * Overload added for issue #556 to support {@link java.net.URI} as an
+     * alternate URL representation without forcing a conversion at the call
+     * site.
+     *
+     * @param uri
+     *            valid URI, e.g. <code>https://www.example.co.uk/</code>
+     * @return PLD, e.g. <code>example.co.uk</code>
+     */
+    public static String getPLD(URI uri) {
+        return getPLD(uri.getHost());
+    }
+
+    /**
+     * Extract the PLD (paid-level domain) from the {@link CrawlerURL}.
+     *
+     * <p>
+     * Overload added for issue #556 so callers holding a {@link CrawlerURL} can
+     * avoid converting to {@link String} or {@link URL} first.
+     *
+     * @param url
+     *            valid URL, e.g. <code>https://www.example.co.uk/</code>
+     * @return PLD, e.g. <code>example.co.uk</code>
+     */
+    public static String getPLD(CrawlerURL url) {
         return getPLD(url.getHost());
     }
 }

--- a/src/main/java/crawlercommons/filters/URLFilter.java
+++ b/src/main/java/crawlercommons/filters/URLFilter.java
@@ -16,16 +16,63 @@
 
 package crawlercommons.filters;
 
+import java.net.URI;
+
+import crawlercommons.url.CrawlerURL;
+
 public abstract class URLFilter {
 
     /**
      * Returns a modified version of the input URL or null if the URL should be
      * removed
-     * 
+     *
      * @param urlString
      *            a URL string to check against filter(s)
      * @return a filtered URL
      **/
     public abstract String filter(String urlString);
+
+    /**
+     * Returns a modified version of the input URL or null if the URL should be
+     * removed.
+     *
+     * <p>
+     * Convenience overload accepting a {@link java.net.URI} (see <a href=
+     * "https://github.com/crawler-commons/crawler-commons/issues/556">issue
+     * #556</a>). The default implementation delegates to
+     * {@link #filter(String)} using the URI's string form, so existing
+     * subclasses keep working without modification. Subclasses may override it
+     * to avoid the round-trip through {@link String}.
+     * </p>
+     *
+     * @param uri
+     *            a URI to check against filter(s)
+     * @return a filtered URL string
+     **/
+    public String filter(URI uri) {
+        return filter(uri.toString());
+    }
+
+    /**
+     * Returns a modified version of the input URL or null if the URL should be
+     * removed.
+     *
+     * <p>
+     * Convenience overload accepting a {@link CrawlerURL} (see <a href=
+     * "https://github.com/crawler-commons/crawler-commons/issues/556">issue
+     * #556</a>). The default implementation delegates to
+     * {@link #filter(String)} using {@link CrawlerURL#toStringURL()}, so
+     * existing subclasses keep working without modification. Subclasses may
+     * override it to reuse the already-parsed representation carried by the
+     * {@link CrawlerURL}.
+     * </p>
+     *
+     * @param url
+     *            a {@link CrawlerURL} to check against filter(s)
+     * @return a filtered URL string
+     **/
+    public String filter(CrawlerURL url) {
+        return filter(url.toStringURL());
+    }
 
 }

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -275,7 +275,7 @@ public class BasicURLNormalizer extends URLFilter {
                     String tempUrl = protocol + "://" + (host == null ? "" : host) + (port == -1 ? "" : ":" + port) + file;
                     file2 = getFileWithNormalizedPath(new URI(tempUrl));
                 } else {
-                    file2 = getFileWithNormalizedPath(new URI(urlString));
+                    file2 = getFileWithNormalizedPath(crawlerUrl.toJavaURI());
                 }
                 if (!file.equals(file2)) {
                     changed = true;

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import crawlercommons.filters.URLFilter;
+import crawlercommons.url.CrawlerURL;
 
 /**
  * Converts URLs to a
@@ -187,12 +188,21 @@ public class BasicURLNormalizer extends URLFilter {
         // escape to ensure URL does not contain illegal characters
         urlString = escapePath(urlString);
 
-        URL url = parseStringToURL(urlString);
-        if (url == null) {
+        // Wrap the parsed URL in a CrawlerURL (issue #556) so the alternate
+        // representations and components are obtained through a single,
+        // lazily-cached carrier instead of repeatedly re-parsing strings.
+        CrawlerURL crawlerUrl = parseStringToCrawlerURL(urlString);
+        if (crawlerUrl == null) {
             LOG.debug("Malformed URL {}", urlString);
             return null;
         }
 
+        // The protocol/host/port/file components are read from the
+        // java.net.URL view of the CrawlerURL. The java.net.URL parsing
+        // semantics (e.g. lowercased protocol, lenient host parsing) are
+        // intentionally retained here to preserve the externally observable
+        // behavior of filter(String).
+        URL url = crawlerUrl.toJavaURL();
         String protocol = url.getProtocol();
         String host = url.getHost();
         int port = url.getPort();
@@ -287,6 +297,25 @@ public class BasicURLNormalizer extends URLFilter {
             }
 
         return urlString;
+    }
+
+    /**
+     * Tries to parse the given string into a {@link CrawlerURL} (issue #556).
+     * The string is first parsed into a {@link java.net.URL} (applying the same
+     * scheme-prefixing fallback as {@link #parseStringToURL(String)}) and then
+     * wrapped, so the lazily-cached java.net.URL view is reused for component
+     * lookups without re-parsing.
+     *
+     * @param urlString a string which possibly contains a URL
+     * @return a {@link CrawlerURL}, or {@code null} if the string cannot be
+     *         parsed into a valid URL
+     */
+    private static CrawlerURL parseStringToCrawlerURL(String urlString) {
+        URL url = parseStringToURL(urlString);
+        if (url == null) {
+            return null;
+        }
+        return CrawlerURL.of(url);
     }
 
     /**

--- a/src/main/java/crawlercommons/robots/SimpleRobotRules.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRules.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import crawlercommons.filters.basic.BasicURLNormalizer;
+import crawlercommons.url.CrawlerURL;
 
 /**
  * {@inheritDoc}
@@ -223,6 +224,60 @@ public class SimpleRobotRules extends BaseRobotRules {
         return isAllowedPath(getPath(url, true));
     }
 
+    /**
+     * Check whether a URL is allowed to be fetched according to the robots
+     * rules.
+     *
+     * <p>
+     * Overload accepting a {@link java.net.URI}, added as part of issue <a
+     * href="https://github.com/crawler-commons/crawler-commons/issues/556">#556</a>
+     * to avoid forced conversions between URL representations. It delegates to
+     * the same matching logic as {@link #isAllowed(String)} and
+     * {@link #isAllowed(URL)}.
+     * </p>
+     *
+     * @see #isAllowed(String)
+     *
+     * @param uri
+     *            URI to be checked
+     * @return true if the URI is allowed
+     */
+    public boolean isAllowed(URI uri) {
+        if (_mode == RobotRulesMode.ALLOW_NONE) {
+            return false;
+        } else if (_mode == RobotRulesMode.ALLOW_ALL) {
+            return true;
+        }
+        return isAllowedPath(getPath(uri, true));
+    }
+
+    /**
+     * Check whether a URL is allowed to be fetched according to the robots
+     * rules.
+     *
+     * <p>
+     * Overload accepting a {@link CrawlerURL}, added as part of issue <a
+     * href="https://github.com/crawler-commons/crawler-commons/issues/556">#556</a>
+     * to avoid forced conversions between URL representations. It delegates to
+     * the same matching logic as {@link #isAllowed(String)} and
+     * {@link #isAllowed(URL)}.
+     * </p>
+     *
+     * @see #isAllowed(String)
+     *
+     * @param url
+     *            {@link CrawlerURL} to be checked
+     * @return true if the URL is allowed
+     */
+    public boolean isAllowed(CrawlerURL url) {
+        if (_mode == RobotRulesMode.ALLOW_NONE) {
+            return false;
+        } else if (_mode == RobotRulesMode.ALLOW_ALL) {
+            return true;
+        }
+        return isAllowedPath(getPath(url, true));
+    }
+
     private boolean isAllowedPath(String pathWithQuery) {
         // Always allow robots.txt
         if (pathWithQuery.equals("/robots.txt")) {
@@ -298,6 +353,28 @@ public class SimpleRobotRules extends BaseRobotRules {
             URL urlObj = new URI(url).toURL();
 
             return getPath(urlObj, getWithQuery);
+        } catch (Exception e) {
+            // If the URL is invalid, we don't really care since the fetch
+            // will fail, so return the root.
+            return "/";
+        }
+    }
+
+    private String getPath(URI uri, boolean getWithQuery) {
+        try {
+            URL urlObj = uri.toURL();
+
+            return getPath(urlObj, getWithQuery);
+        } catch (Exception e) {
+            // If the URI is invalid, we don't really care since the fetch
+            // will fail, so return the root.
+            return "/";
+        }
+    }
+
+    private String getPath(CrawlerURL url, boolean getWithQuery) {
+        try {
+            return getPath(url.toJavaURL(), getWithQuery);
         } catch (Exception e) {
             // If the URL is invalid, we don't really care since the fetch
             // will fail, so return the root.

--- a/src/main/java/crawlercommons/sitemaps/SiteMapURL.java
+++ b/src/main/java/crawlercommons/sitemaps/SiteMapURL.java
@@ -33,6 +33,7 @@ import java.util.TreeMap;
 
 import crawlercommons.sitemaps.extension.Extension;
 import crawlercommons.sitemaps.extension.ExtensionMetadata;
+import crawlercommons.url.CrawlerURL;
 
 /**
  * The SitemapUrl class represents a URL found in a Sitemap.
@@ -113,6 +114,126 @@ public class SiteMapURL implements Serializable {
     }
 
     /**
+     * Constructor mirroring {@link #SiteMapURL(URL, boolean)} but accepting a
+     * {@link java.net.URI} so that callers using URI representations do not need
+     * to convert beforehand (see issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a {@link java.net.URI}
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(URI url, boolean valid) {
+        setUrl(url);
+        setValid(valid);
+    }
+
+    /**
+     * Constructor mirroring
+     * {@link #SiteMapURL(URL, Date, ChangeFrequency, double, boolean)} but
+     * accepting a {@link java.net.URI} (see issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a {@link java.net.URI}
+     * @param lastModified
+     *            when the URL was last modified
+     * @param changeFreq
+     *            how often the URL changes
+     * @param priority
+     *            a value between [0.0 - 1.0]
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(URI url, Date lastModified, ChangeFrequency changeFreq, double priority, boolean valid) {
+        this(url, valid);
+        setLastModified(lastModified);
+        setChangeFrequency(changeFreq);
+        setPriority(priority);
+    }
+
+    /**
+     * Constructor mirroring
+     * {@link #SiteMapURL(URL, ZonedDateTime, ChangeFrequency, double, boolean)}
+     * but accepting a {@link java.net.URI} (see issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a {@link java.net.URI}
+     * @param lastModified
+     *            when the URL was last modified
+     * @param changeFreq
+     *            how often the URL changes
+     * @param priority
+     *            a value between [0.0 - 1.0]
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(URI url, ZonedDateTime lastModified, ChangeFrequency changeFreq, double priority, boolean valid) {
+        this(url, Date.from(lastModified.toInstant()), changeFreq, priority, valid);
+    }
+
+    /**
+     * Constructor mirroring {@link #SiteMapURL(URL, boolean)} but accepting a
+     * {@link crawlercommons.url.CrawlerURL} so that callers using the
+     * crawler-commons URL representation do not need to convert beforehand (see
+     * issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a
+     *            {@link crawlercommons.url.CrawlerURL}
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(CrawlerURL url, boolean valid) {
+        setUrl(url);
+        setValid(valid);
+    }
+
+    /**
+     * Constructor mirroring
+     * {@link #SiteMapURL(URL, Date, ChangeFrequency, double, boolean)} but
+     * accepting a {@link crawlercommons.url.CrawlerURL} (see issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a
+     *            {@link crawlercommons.url.CrawlerURL}
+     * @param lastModified
+     *            when the URL was last modified
+     * @param changeFreq
+     *            how often the URL changes
+     * @param priority
+     *            a value between [0.0 - 1.0]
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(CrawlerURL url, Date lastModified, ChangeFrequency changeFreq, double priority, boolean valid) {
+        this(url, valid);
+        setLastModified(lastModified);
+        setChangeFrequency(changeFreq);
+        setPriority(priority);
+    }
+
+    /**
+     * Constructor mirroring
+     * {@link #SiteMapURL(URL, ZonedDateTime, ChangeFrequency, double, boolean)}
+     * but accepting a {@link crawlercommons.url.CrawlerURL} (see issue #556).
+     *
+     * @param url
+     *            URL of the sitemap entry as a
+     *            {@link crawlercommons.url.CrawlerURL}
+     * @param lastModified
+     *            when the URL was last modified
+     * @param changeFreq
+     *            how often the URL changes
+     * @param priority
+     *            a value between [0.0 - 1.0]
+     * @param valid
+     *            whether the Sitemap is valid syntax or not
+     */
+    public SiteMapURL(CrawlerURL url, ZonedDateTime lastModified, ChangeFrequency changeFreq, double priority, boolean valid) {
+        this(url, Date.from(lastModified.toInstant()), changeFreq, priority, valid);
+    }
+
+    /**
      * Return the URL.
      * 
      * @return URL
@@ -142,6 +263,48 @@ public class SiteMapURL implements Serializable {
         try {
             this.url = new URI(url).toURL();
         } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
+            LOG.error("Bad url: [{}], Exception: {}", url, e.toString());
+            this.url = null;
+        }
+    }
+
+    /**
+     * Set the URL from a {@link java.net.URI} (see issue #556).
+     *
+     * @param url
+     *            of the sitemap. In case the URI cannot be converted to a
+     *            {@link URL}, the current url in this instance will be set to
+     *            NULL
+     */
+    public void setUrl(URI url) {
+        if (url == null) {
+            this.url = null;
+            return;
+        }
+        try {
+            this.url = url.toURL();
+        } catch (MalformedURLException | IllegalArgumentException e) {
+            LOG.error("Bad url: [{}], Exception: {}", url, e.toString());
+            this.url = null;
+        }
+    }
+
+    /**
+     * Set the URL from a {@link crawlercommons.url.CrawlerURL} (see issue #556).
+     *
+     * @param url
+     *            of the sitemap. In case the wrapped URL cannot be converted to
+     *            a {@link URL}, the current url in this instance will be set to
+     *            NULL
+     */
+    public void setUrl(CrawlerURL url) {
+        if (url == null) {
+            this.url = null;
+            return;
+        }
+        try {
+            this.url = url.toJavaURL();
+        } catch (RuntimeException e) {
             LOG.error("Bad url: [{}], Exception: {}", url, e.toString());
             this.url = null;
         }

--- a/src/main/java/crawlercommons/url/CrawlerURL.java
+++ b/src/main/java/crawlercommons/url/CrawlerURL.java
@@ -1,0 +1,389 @@
+/**
+ * Copyright 2026 Crawler-Commons
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.url;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Objects;
+
+/**
+ * A lightweight, immutable wrapper around a single URL whose alternate
+ * representations ({@link java.net.URI}, {@link java.net.URL} and the
+ * {@link String} form) and parsed components (scheme, host, port, path, query,
+ * fragment, user-info, authority) are computed <em>lazily on first access</em>
+ * and then <em>cached</em> in private fields, so repeated access never
+ * re-parses.
+ *
+ * <p>
+ * This class exists to address <a href=
+ * "https://github.com/crawler-commons/crawler-commons/issues/556">issue
+ * #556</a>: crawler-commons APIs historically accepted either {@link String} or
+ * {@link java.net.URL}, never {@link java.net.URI}, forcing downstream crawlers
+ * to repeatedly convert between representations. At the scale of hundreds of
+ * millions of URLs those conversions are wasteful. {@code CrawlerURL} lets a
+ * caller hand crawler-commons whatever representation it already has and only
+ * pay the cost of converting to another representation if and when it is
+ * actually needed -- and then only once.
+ * </p>
+ *
+ * <h2>Error handling</h2>
+ * <p>
+ * The original input is always retained verbatim and is returned by
+ * {@link #toStringURL()} without any parsing. Conversions ({@link #toJavaURL()},
+ * {@link #toJavaURI()}) and component accessors parse lazily. If parsing fails,
+ * the conversion getters throw an <em>unchecked</em>
+ * {@link IllegalStateException} wrapping the underlying
+ * {@link java.net.MalformedURLException} / {@link java.net.URISyntaxException}.
+ * This keeps call sites clean (no checked exceptions). Both a successful parse
+ * and a parse failure are cached, so a malformed instance fails fast and
+ * cheaply on every subsequent call.
+ * </p>
+ *
+ * <h2>Thread-safety</h2>
+ * <p>
+ * Instances are effectively immutable. The lazy caches use plain (non-volatile)
+ * fields; in the presence of a data race the worst that can happen is that the
+ * (idempotent) computation is performed by more than one thread. No
+ * synchronization is used by design.
+ * </p>
+ *
+ * @since 1.6
+ */
+public final class CrawlerURL {
+
+    /**
+     * The canonical string form of the URL. Never {@code null}. Set once at
+     * construction time, so {@link #toStringURL()} never has to parse anything.
+     */
+    private final String stringUrl;
+
+    private URI uri;
+    private boolean uriComputed;
+    private IllegalStateException uriError;
+
+    private URL url;
+    private boolean urlComputed;
+    private IllegalStateException urlError;
+
+    private boolean componentsComputed;
+    private String scheme;
+    private String host;
+    private int port = -1;
+    private String path;
+    private String query;
+    private String fragment;
+    private String userInfo;
+    private String authority;
+
+    private CrawlerURL(String stringUrl, URI uri, URL url) {
+        this.stringUrl = stringUrl;
+        if (uri != null) {
+            this.uri = uri;
+            this.uriComputed = true;
+        }
+        if (url != null) {
+            this.url = url;
+            this.urlComputed = true;
+        }
+    }
+
+    /**
+     * Creates a {@code CrawlerURL} from its {@link String} representation. The
+     * string is stored verbatim and only parsed lazily when an alternate
+     * representation or a component is requested.
+     *
+     * @param url
+     *            the URL in string form; must not be {@code null}
+     * @return a new {@code CrawlerURL}
+     * @see <a href=
+     *      "https://github.com/crawler-commons/crawler-commons/issues/556">issue
+     *      #556</a>
+     */
+    public static CrawlerURL of(String url) {
+        Objects.requireNonNull(url, "url must not be null");
+        return new CrawlerURL(url, null, null);
+    }
+
+    /**
+     * Creates a {@code CrawlerURL} from a {@link java.net.URI}. The supplied URI
+     * is cached, so {@link #toJavaURI()} returns it without re-parsing.
+     *
+     * @param uri
+     *            the source URI; must not be {@code null}
+     * @return a new {@code CrawlerURL}
+     */
+    public static CrawlerURL of(URI uri) {
+        Objects.requireNonNull(uri, "uri must not be null");
+        return new CrawlerURL(uri.toString(), uri, null);
+    }
+
+    /**
+     * Creates a {@code CrawlerURL} from a {@link java.net.URL}. The supplied URL
+     * is cached, so {@link #toJavaURL()} returns it without re-parsing.
+     *
+     * @param url
+     *            the source URL; must not be {@code null}
+     * @return a new {@code CrawlerURL}
+     */
+    public static CrawlerURL of(URL url) {
+        Objects.requireNonNull(url, "url must not be null");
+        return new CrawlerURL(url.toString(), null, url);
+    }
+
+    /**
+     * Alias of {@link #of(URI)}.
+     *
+     * @param uri
+     *            the source URI; must not be {@code null}
+     * @return a new {@code CrawlerURL}
+     */
+    public static CrawlerURL fromJavaURI(URI uri) {
+        return of(uri);
+    }
+
+    /**
+     * Alias of {@link #of(URL)}.
+     *
+     * @param url
+     *            the source URL; must not be {@code null}
+     * @return a new {@code CrawlerURL}
+     */
+    public static CrawlerURL fromJavaURL(URL url) {
+        return of(url);
+    }
+
+    /**
+     * Returns the {@link java.net.URL} representation, computing and caching it
+     * on first access.
+     *
+     * @return the {@code URL} form of this instance
+     * @throws IllegalStateException
+     *             if the underlying value cannot be parsed as a {@code URL}
+     *             (wraps the {@link java.net.MalformedURLException})
+     */
+    public URL toJavaURL() {
+        if (!urlComputed) {
+            try {
+                // Convert via URI to avoid the deprecated URL(String)
+                // constructor, reusing the lazily-cached URI when present.
+                URI u = (uri != null) ? uri : new URI(stringUrl);
+                this.uri = u;
+                this.uriComputed = true;
+                this.url = u.toURL();
+            } catch (MalformedURLException | URISyntaxException | IllegalArgumentException e) {
+                this.urlError = new IllegalStateException("Cannot convert to java.net.URL: " + stringUrl, e);
+            }
+            this.urlComputed = true;
+        }
+        if (urlError != null) {
+            throw urlError;
+        }
+        return url;
+    }
+
+    /**
+     * Returns the {@link java.net.URI} representation, computing and caching it
+     * on first access.
+     *
+     * @return the {@code URI} form of this instance
+     * @throws IllegalStateException
+     *             if the underlying value cannot be parsed as a {@code URI}
+     *             (wraps the {@link java.net.URISyntaxException})
+     */
+    public URI toJavaURI() {
+        if (!uriComputed) {
+            try {
+                this.uri = new URI(stringUrl);
+            } catch (URISyntaxException e) {
+                this.uriError = new IllegalStateException("Cannot convert to java.net.URI: " + stringUrl, e);
+            }
+            this.uriComputed = true;
+        }
+        if (uriError != null) {
+            throw uriError;
+        }
+        return uri;
+    }
+
+    /**
+     * Returns the string form of this URL. This is the original input (or the
+     * {@code toString()} of the original {@code URI}/{@code URL}) and is
+     * returned without any parsing. Never {@code null} for a valid instance.
+     *
+     * @return the string form of this URL
+     */
+    public String toStringURL() {
+        return stringUrl;
+    }
+
+    /**
+     * Parses the URL into its components exactly once, using
+     * {@link java.net.URI} semantics. Falls back to {@link java.net.URL}
+     * semantics when the value is a valid {@code URL} but not a valid
+     * {@code URI}. If neither parses, all components remain {@code null} / -1.
+     */
+    private void ensureComponents() {
+        if (componentsComputed) {
+            return;
+        }
+        URI parsedUri = null;
+        try {
+            parsedUri = toJavaURI();
+        } catch (IllegalStateException ignore) {
+            // not a valid URI; fall back to URL below
+        }
+        if (parsedUri != null) {
+            this.scheme = parsedUri.getScheme();
+            this.host = parsedUri.getHost();
+            this.port = parsedUri.getPort();
+            this.path = parsedUri.getPath();
+            this.query = parsedUri.getQuery();
+            this.fragment = parsedUri.getFragment();
+            this.userInfo = parsedUri.getUserInfo();
+            this.authority = parsedUri.getAuthority();
+        } else {
+            try {
+                URL parsedUrl = toJavaURL();
+                this.scheme = parsedUrl.getProtocol();
+                this.host = parsedUrl.getHost() == null || parsedUrl.getHost().isEmpty() ? null : parsedUrl.getHost();
+                this.port = parsedUrl.getPort();
+                this.path = parsedUrl.getPath();
+                this.query = parsedUrl.getQuery();
+                this.fragment = parsedUrl.getRef();
+                this.userInfo = parsedUrl.getUserInfo();
+                this.authority = parsedUrl.getAuthority();
+            } catch (IllegalStateException ignore) {
+                // neither URI nor URL; leave components at their defaults
+            }
+        }
+        this.componentsComputed = true;
+    }
+
+    /**
+     * Returns the scheme (a.k.a. protocol), or {@code null} if undefined.
+     *
+     * @return the scheme component
+     */
+    public String getScheme() {
+        ensureComponents();
+        return scheme;
+    }
+
+    /**
+     * Returns the host, or {@code null} if undefined.
+     *
+     * @return the host component
+     */
+    public String getHost() {
+        ensureComponents();
+        return host;
+    }
+
+    /**
+     * Returns the port, or {@code -1} if unspecified.
+     *
+     * @return the port component, or {@code -1}
+     */
+    public int getPort() {
+        ensureComponents();
+        return port;
+    }
+
+    /**
+     * Returns the path, or {@code null} if undefined.
+     *
+     * @return the path component
+     */
+    public String getPath() {
+        ensureComponents();
+        return path;
+    }
+
+    /**
+     * Returns the query string, or {@code null} if undefined.
+     *
+     * @return the query component
+     */
+    public String getQuery() {
+        ensureComponents();
+        return query;
+    }
+
+    /**
+     * Returns the fragment (a.k.a. ref), or {@code null} if undefined.
+     *
+     * @return the fragment component
+     */
+    public String getFragment() {
+        ensureComponents();
+        return fragment;
+    }
+
+    /**
+     * Returns the user-info, or {@code null} if undefined.
+     *
+     * @return the user-info component
+     */
+    public String getUserInfo() {
+        ensureComponents();
+        return userInfo;
+    }
+
+    /**
+     * Returns the authority, or {@code null} if undefined.
+     *
+     * @return the authority component
+     */
+    public String getAuthority() {
+        ensureComponents();
+        return authority;
+    }
+
+    /**
+     * Two {@code CrawlerURL} instances are equal iff their string forms
+     * ({@link #toStringURL()}) are equal.
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CrawlerURL)) {
+            return false;
+        }
+        return stringUrl.equals(((CrawlerURL) o).stringUrl);
+    }
+
+    /**
+     * Hash code consistent with {@link #equals(Object)}; based on the string
+     * form.
+     */
+    @Override
+    public int hashCode() {
+        return stringUrl.hashCode();
+    }
+
+    /**
+     * Returns {@link #toStringURL()}.
+     */
+    @Override
+    public String toString() {
+        return toStringURL();
+    }
+}

--- a/src/main/java/crawlercommons/utils/URLUtils.java
+++ b/src/main/java/crawlercommons/utils/URLUtils.java
@@ -4,6 +4,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 
+import crawlercommons.url.CrawlerURL;
+
 public class URLUtils {
 
     /**
@@ -51,6 +53,67 @@ public class URLUtils {
             }
 
             return base.toURI().resolve(resolvedSpec).toURL();
+        } catch (Exception e) {
+            throw (MalformedURLException) new MalformedURLException(e.getMessage()).initCause(e);
+        }
+    }
+
+    /**
+     * Resolves a URL against a base URL.
+     *
+     * <p>
+     * Overload accepting a {@code java.net.URI} base, added for issue #556 to
+     * let callers that already hold a {@code URI} avoid converting to
+     * {@code java.net.URL} first. It delegates to
+     * {@link #resolve(URL, String)} so resolution semantics stay identical.
+     * </p>
+     *
+     * @param base
+     *            the base URL, or {@code null}
+     * @param spec
+     *            the URL specification to resolve
+     * @return the resolved URL
+     * @throws MalformedURLException
+     *             if the URL cannot be resolved
+     */
+    public static URL resolve(URI base, String spec) throws MalformedURLException {
+        if (base == null) {
+            return resolve((URL) null, spec);
+        }
+        try {
+            return resolve(base.toURL(), spec);
+        } catch (MalformedURLException e) {
+            throw e;
+        } catch (Exception e) {
+            throw (MalformedURLException) new MalformedURLException(e.getMessage()).initCause(e);
+        }
+    }
+
+    /**
+     * Resolves a URL against a base URL.
+     *
+     * <p>
+     * Overload accepting a {@link CrawlerURL} base, added for issue #556 to let
+     * callers pass the lazily-converting wrapper directly. It delegates to
+     * {@link #resolve(URL, String)} so resolution semantics stay identical.
+     * </p>
+     *
+     * @param base
+     *            the base URL, or {@code null}
+     * @param spec
+     *            the URL specification to resolve
+     * @return the resolved URL
+     * @throws MalformedURLException
+     *             if the URL cannot be resolved
+     */
+    public static URL resolve(CrawlerURL base, String spec) throws MalformedURLException {
+        if (base == null) {
+            return resolve((URL) null, spec);
+        }
+        try {
+            return resolve(base.toJavaURL(), spec);
+        } catch (MalformedURLException e) {
+            throw e;
         } catch (Exception e) {
             throw (MalformedURLException) new MalformedURLException(e.getMessage()).initCause(e);
         }

--- a/src/test/java/crawlercommons/url/CrawlerURLTest.java
+++ b/src/test/java/crawlercommons/url/CrawlerURLTest.java
@@ -25,6 +25,7 @@ import java.net.URL;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -133,8 +134,8 @@ public class CrawlerURLTest {
         assertNotEquals(a, c);
         assertEquals(SAMPLE, a.toString());
         assertEquals(a.toStringURL(), a.toString());
-        assertNotEquals(a, null);
-        assertNotEquals(a, "a string");
+        assertNotNull(a);
+        assertNotEquals("a string", a);
         assertTrue(a.equals(a));
     }
 

--- a/src/test/java/crawlercommons/url/CrawlerURLTest.java
+++ b/src/test/java/crawlercommons/url/CrawlerURLTest.java
@@ -1,0 +1,185 @@
+/**
+ * Copyright 2026 Crawler-Commons
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package crawlercommons.url;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class CrawlerURLTest {
+
+    private static final String SAMPLE = "http://user:pw@www.example.com:8080/a/b/c?q=1&r=2#frag";
+
+    @Test
+    public final void testRoundTripFromString() throws Exception {
+        CrawlerURL u = CrawlerURL.of(SAMPLE);
+        assertEquals(SAMPLE, u.toStringURL());
+        assertEquals(new URI(SAMPLE), u.toJavaURI());
+        assertEquals(new URI(SAMPLE).toURL(), u.toJavaURL());
+    }
+
+    @Test
+    public final void testRoundTripFromURI() throws Exception {
+        URI uri = new URI(SAMPLE);
+        CrawlerURL u = CrawlerURL.of(uri);
+        assertEquals(SAMPLE, u.toStringURL());
+        assertEquals(uri, u.toJavaURI());
+        assertEquals(uri.toURL(), u.toJavaURL());
+    }
+
+    @Test
+    public final void testRoundTripFromURL() throws Exception {
+        URL url = new URI(SAMPLE).toURL();
+        CrawlerURL u = CrawlerURL.of(url);
+        assertEquals(url.toString(), u.toStringURL());
+        assertEquals(url, u.toJavaURL());
+        assertEquals(new URI(SAMPLE), u.toJavaURI());
+    }
+
+    @Test
+    public final void testFactoryAliases() throws Exception {
+        URI uri = new URI(SAMPLE);
+        URL url = uri.toURL();
+        assertEquals(CrawlerURL.of(uri), CrawlerURL.fromJavaURI(uri));
+        assertEquals(CrawlerURL.of(url), CrawlerURL.fromJavaURL(url));
+    }
+
+    @Test
+    public final void testConversionsCached() {
+        CrawlerURL u = CrawlerURL.of(SAMPLE);
+        URI uri1 = u.toJavaURI();
+        URI uri2 = u.toJavaURI();
+        assertSame(uri1, uri2, "URI should be cached and identical on repeated access");
+
+        URL url1 = u.toJavaURL();
+        URL url2 = u.toJavaURL();
+        assertSame(url1, url2, "URL should be cached and identical on repeated access");
+    }
+
+    @Test
+    public final void testSuppliedRepresentationsAreCached() throws Exception {
+        URI uri = new URI(SAMPLE);
+        assertSame(uri, CrawlerURL.of(uri).toJavaURI(), "supplied URI must be returned as-is");
+
+        URL url = uri.toURL();
+        assertSame(url, CrawlerURL.of(url).toJavaURL(), "supplied URL must be returned as-is");
+    }
+
+    @Test
+    public final void testComponentExtraction() {
+        CrawlerURL u = CrawlerURL.of(SAMPLE);
+        assertEquals("http", u.getScheme());
+        assertEquals("www.example.com", u.getHost());
+        assertEquals(8080, u.getPort());
+        assertEquals("/a/b/c", u.getPath());
+        assertEquals("q=1&r=2", u.getQuery());
+        assertEquals("frag", u.getFragment());
+        assertEquals("user:pw", u.getUserInfo());
+        assertEquals("user:pw@www.example.com:8080", u.getAuthority());
+    }
+
+    @Test
+    public final void testDefaultPortIsMinusOne() {
+        CrawlerURL u = CrawlerURL.of("http://www.example.com/path");
+        assertEquals(-1, u.getPort());
+        assertEquals("www.example.com", u.getHost());
+        assertNull(u.getQuery());
+        assertNull(u.getFragment());
+        assertNull(u.getUserInfo());
+    }
+
+    @Test
+    public final void testComponentsCached() {
+        CrawlerURL u = CrawlerURL.of(SAMPLE);
+        assertEquals(u.getHost(), u.getHost());
+        assertEquals(u.getScheme(), u.getScheme());
+        assertEquals(u.getPath(), u.getPath());
+        // Same string instance returned each time (cached, not re-parsed).
+        assertSame(u.getHost(), u.getHost());
+    }
+
+    @Test
+    public final void testEqualsHashCodeToString() {
+        CrawlerURL a = CrawlerURL.of(SAMPLE);
+        CrawlerURL b = CrawlerURL.of(SAMPLE);
+        CrawlerURL c = CrawlerURL.of("http://other.example.org/");
+
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+        assertNotEquals(a, c);
+        assertEquals(SAMPLE, a.toString());
+        assertEquals(a.toStringURL(), a.toString());
+        assertNotEquals(a, null);
+        assertNotEquals(a, "a string");
+        assertTrue(a.equals(a));
+    }
+
+    @Test
+    public final void testEqualsAcrossFactories() throws Exception {
+        CrawlerURL fromString = CrawlerURL.of(SAMPLE);
+        CrawlerURL fromUri = CrawlerURL.of(new URI(SAMPLE));
+        assertEquals(fromString, fromUri);
+        assertEquals(fromString.hashCode(), fromUri.hashCode());
+    }
+
+    @Test
+    public final void testMalformedUrlThrowsUnchecked() {
+        // Not a valid URL (no protocol) -> toJavaURL must throw unchecked.
+        CrawlerURL u = CrawlerURL.of("www.example.com/no-scheme");
+        IllegalStateException ex = assertThrows(IllegalStateException.class, u::toJavaURL);
+        assertNotNull(ex.getCause());
+        // string form is always available regardless
+        assertEquals("www.example.com/no-scheme", u.toStringURL());
+    }
+
+    @Test
+    public final void testMalformedUriThrowsUnchecked() {
+        // Space is illegal in a raw URI.
+        CrawlerURL u = CrawlerURL.of("http://example.com/a b c");
+        assertThrows(IllegalStateException.class, u::toJavaURI);
+        assertEquals("http://example.com/a b c", u.toStringURL());
+    }
+
+    @Test
+    public final void testMalformedConversionFailureCached() {
+        CrawlerURL u = CrawlerURL.of("http://example.com/a b c");
+        IllegalStateException first = assertThrows(IllegalStateException.class, u::toJavaURI);
+        IllegalStateException second = assertThrows(IllegalStateException.class, u::toJavaURI);
+        assertSame(first, second, "the cached failure should be reused, not recomputed");
+    }
+
+    @Test
+    public final void testStringFactoryRejectsNull() {
+        assertThrows(NullPointerException.class, () -> CrawlerURL.of((String) null));
+        assertThrows(NullPointerException.class, () -> CrawlerURL.of((URI) null));
+        assertThrows(NullPointerException.class, () -> CrawlerURL.of((URL) null));
+    }
+
+    private static void assertNotNull(Object o) {
+        assertFalse(o == null, "expected non-null");
+    }
+}


### PR DESCRIPTION
## Summary

Resolves #556. The crawler-commons API inconsistently accepts `String` or
`java.net.URL`, never `java.net.URI`, forcing downstream crawlers (Nutch,
StormCrawler, Heritrix, BUbiNG) into wasteful conversions between URL
representations. Following the discussion in #556, this introduces a custom
URL class that lazily converts between representations and caches the results,
plus backward-compatible overloads across the public API.