### PR TITLE
Fix StringIndexOutOfBoundsException in BasicURLNormalizer when path contains percent-encoded unreserved chars (#559)

### DIFF
--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -318,23 +318,27 @@ public class BasicURLNormalizer extends URLFilter {
      * @return a normalized URL file
      */
     private String normalizeUrlFile(String file) {
+        // Normalize (unescape unreserved percent-encoded characters) before
+        // locating the query part. Unescaping can shorten the file (e.g. "%2D"
+        // -> "-"), so an index computed on the original string would be stale
+        // afterwards and may point past the end of the unescaped string
+        // (issue #559). Only unreserved characters are unescaped, so this
+        // cannot introduce a new '?' query delimiter into the path.
+        file = unescapePath(file);
+
         // find the beginning of the query parameters
         int endPathIdx = file.indexOf('?');
         if (endPathIdx == -1) {
-            // no query parameters, just properly normalize the path
-            return unescapePath(file);
+            // no query parameters, path is already normalized
+            return file;
         }
 
         int queryStartIdx = endPathIdx + 1;
         if (queryStartIdx >= file.length()) {
             // question mark was the last char in the file, so the query parameters
-            // string is empty. we can just remove the question mark and properly
-            // normalize the path.
-            final String path = file.substring(0, file.length() - 1);
-            return unescapePath(path);
+            // string is empty. we can just remove the question mark.
+            return file.substring(0, file.length() - 1);
         }
-
-        file = unescapePath(file);
 
         List<NameValuePair> pairs =
                 parseQueryParameters(file, queryStartIdx, queryParamsToRemove);

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -65,7 +65,12 @@ public class BasicURLNormalizerTest {
                     // not a query param, slash must remain
                     "https://example.com/path/show.php?/category/3,", //
                     // not a query param, slash and %2F have distinct semantics
-                    "https://example.com/?categoryA/categoryB/this_%2F_that," })
+                    "https://example.com/?categoryA/categoryB/this_%2F_that,", //
+                    // issue #559: percent-encoded unreserved chars in the path
+                    // shorten the file when unescaped; the query must still be
+                    // parsed without a StringIndexOutOfBoundsException
+                    "https://example.org/p%2d1/p%2d2/?q=f,https://example.org/p-1/p-2/?q=f", //
+                    "https://example.org/p%2d1/p%2d2/?b=2&a=1,https://example.org/p-1/p-2/?a=1&b=2" })
     public void testQueryParameters(String url, String urlNorm) {
         normalizer = new BasicURLNormalizer();
         if (urlNorm == null) {


### PR DESCRIPTION
Fixes #559.

When the path of a URL contains percent-encoded unreserved characters (e.g. `%2D` for a hyphen), `normalizeUrlFile` computed the query-start index on the original `file` string but used it after `unescapePath(file)` had shortened the string. The stale index pointed past the end of the unescaped string, causing a StringIndexOutOfBoundsException (and, in related cases, a malformed path slice).

Fix: unescape the file first, then locate the `?` and compute the query index on the already-normalized string. Only unreserved characters are unescaped, so this cannot introduce a new `?` delimiter into the path.

Added regression tests to `BasicURLNormalizerTest#testQueryParameters`, including the exact case from the issue (`https://example.org/p%2d1/p%2d2/?q=f`).