### PR TITLE
Fix per-group robots.txt extension values leaking from wildcard group

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -296,6 +296,21 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             _curRules.clearRules();
         }
 
+        /**
+         * Clear the per-group extension data collected so far in the current
+         * rules. Called when a wildcard group is superseded by a matching
+         * specific user-agent group, so that per-group extension values (e.g.
+         * Clean-param) collected under the wildcard do not leak into the rules
+         * of the matched agent. Global (file-wide) extensions are not affected.
+         */
+        public void clearPerGroupExtensions() {
+            for (RobotsExtension ext : RobotsExtension.values()) {
+                if (ext.isPerGroup()) {
+                    _curRules.clearExtensionData(ext);
+                }
+            }
+        }
+
         public void addRule(String prefix, boolean allow) {
             _curRules.addRule(prefix, allow);
         }
@@ -959,10 +974,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
                 state.setAddingCrawlDelay(true);
             } else if (targetNames.contains(agentName) || (!isValidUserAgentToObey(agentName) && userAgentProductTokenPartialMatch(agentName, targetNames))) {
                 if (state.isMatchedWildcard()) {
-                    // Clear rules and Crawl-delay of the wildcard user-agent
-                    // found before the non-wildcard user-agent match.
+                    // Clear rules, Crawl-delay and per-group extensions of the
+                    // wildcard user-agent found before the non-wildcard
+                    // user-agent match.
                     state.clearRules();
                     state.clearCrawlDelay();
+                    state.clearPerGroupExtensions();
                 }
                 state.setMatchedRealName(true);
                 state.setAddingRules(true);
@@ -1004,10 +1021,12 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             }
             if (matched) {
                 if (state.isMatchedWildcard()) {
-                    // Clear rules and Crawl-delay of the wildcard user-agent
-                    // found before the non-wildcard user-agent match.
+                    // Clear rules, Crawl-delay and per-group extensions of the
+                    // wildcard user-agent found before the non-wildcard
+                    // user-agent match.
                     state.clearRules();
                     state.clearCrawlDelay();
+                    state.clearPerGroupExtensions();
                 }
                 state.setMatchedRealName(true);
                 state.setAddingRules(true);

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1496,6 +1496,32 @@ public class SimpleRobotRulesParserTest {
     }
 
     @Test
+    void testExtensionPerGroupNotLeakedFromWildcard() {
+        // Per-group extension values collected under the wildcard group must
+        // not leak into the rules of a specific agent that supersedes the
+        // wildcard group (same as the allow/disallow rules and the crawl-delay,
+        // which are cleared when the specific group matches).
+        final String robotsTxt = "User-agent: *" + CRLF //
+                        + "Request-rate: 1/10m" + CRLF //
+                        + "Disallow: /wild/" + CRLF //
+                        + CRLF //
+                        + "User-agent: mybot" + CRLF //
+                        + "Disallow: /bot/";
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableExtension(RobotsExtension.REQUEST_RATE);
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotsTxt.getBytes(UTF_8), "text/plain", Set.of("mybot"));
+
+        // sanity: the wildcard rules were cleared in favour of the mybot group
+        assertTrue(rules.isAllowed("http://www.example.com/wild/"), "Wildcard disallow rules should be cleared for the matched agent");
+        assertFalse(rules.isAllowed("http://www.example.com/bot/"), "The matched agent's own disallow rules should apply");
+
+        // the Request-rate from the wildcard group must not leak into mybot
+        assertNull(rules.getExtensionData(RobotsExtension.REQUEST_RATE),
+                        "Per-group extension collected under the wildcard group should not leak into the matched agent's rules");
+    }
+
+    @Test
     void testExtensionMultipleValues() {
         final String robotsTxt = "User-agent: *" + CRLF //
                         + "Allow: /" + CRLF //


### PR DESCRIPTION
## Problem

When a specific `User-agent` group supersedes an earlier wildcard (`*`) group, `handleUserAgent` clears the wildcard's allow/disallow rules and crawl-delay — but it did **not** clear per-group extension data (e.g. `Clean-param`, `Request-rate`, `No-index`, `Visit-time`, `Comment`, `Robot-version`) collected under the wildcard group. Those values leaked into the matched agent's rules.

### Reproduction

```
User-agent: *
Request-rate: 1/10m
Disallow: /wild/

User-agent: mybot
Disallow: /bot/
```

Parsing for `mybot` (with `REQUEST_RATE` enabled) correctly drops `Disallow: /wild/`, but `getExtensionData(REQUEST_RATE)` still returns `1/10m` from the wildcard group.

## Fix

Clear per-group extension data alongside the rules and crawl-delay when a matching specific user-agent group replaces the wildcard group (both the exact-matching and legacy prefix-matching paths). Global / file-wide extensions (`LLM-Policy`, `Host`, `Content-Signals`) are intentionally unaffected.

## Tests

Added `testExtensionPerGroupNotLeakedFromWildcard`. Full `SimpleRobotRulesParserTest` suite passes (233 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)