### PR TITLE
Do not add unescaped Allow path when path normalization fails

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -1095,18 +1095,17 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
 
         try {
             path = normalizePathDirective(path);
+            if (path.length() == 0) {
+                /*
+                 * Allow: <nothing> => allow all.
+                 *
+                 * See handleDisallow(...): We ignore the empty allow statement.
+                 */
+            } else {
+                state.addRule(path, true);
+            }
         } catch (Exception e) {
             reportWarning(state, "Error parsing robots rules - can't decode path: {}", path);
-        }
-
-        if (path.length() == 0) {
-            /*
-             * Allow: <nothing> => allow all.
-             * 
-             * See handleDisallow(...): We ignore the empty allow statement.
-             */
-        } else {
-            state.addRule(path, true);
         }
     }
 


### PR DESCRIPTION
## Problem

`handleAllow()` calls `normalizePathDirective()` inside a `try`/`catch`, but adds the rule **after** the catch block:

```java
try {
    path = normalizePathDirective(path);
} catch (Exception e) {
    reportWarning(state, "Error parsing robots rules - can't decode path: {}", path);
}
if (path.length() == 0) { ... } else {
    state.addRule(path, true);   // still runs on exception, with the raw path
}
```

So when normalization/decoding fails, the parser logs a warning **and then still installs an allow rule using the raw, un-normalized path**. The sibling `handleDisallow()` keeps `addRule()` inside the `try`, so on failure it drops the rule instead.

## Fix

Move the rule creation inside the `try` block so `handleAllow()` behaves identically to `handleDisallow()`: a normalization failure results in no rule being added rather than a rule with an unescaped path.

## Tests

`SimpleRobotRulesParserTest` suite passes (232 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)