### PR TITLE
Avoid NullPointerException in getNumWarnings() before first parse

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -508,7 +508,7 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
     public static final long DEFAULT_MAX_CRAWL_DELAY = 300000;
 
     // number of warnings found in the latest processed robots.txt file
-    private ThreadLocal<Integer> _numWarningsDuringLastParse = new ThreadLocal<>();
+    private ThreadLocal<Integer> _numWarningsDuringLastParse = ThreadLocal.withInitial(() -> 0);
 
     private int _maxWarnings;
     private long _maxCrawlDelay;

--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1719,6 +1719,14 @@ public class SimpleRobotRulesParserTest {
         assertEquals("This is a comment about bot1", comment.getValues().get(0));
     }
 
+    @Test
+    void testGetNumWarningsBeforeParse() {
+        // getNumWarnings() must not throw a NullPointerException when called on
+        // a thread that has not yet parsed any robots.txt file.
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        assertEquals(0, robotParser.getNumWarnings());
+    }
+
     private byte[] readFile(String filename) throws Exception {
         byte[] bigBuffer = new byte[100000];
         InputStream is = SimpleRobotRulesParserTest.class.getResourceAsStream(filename);


### PR DESCRIPTION
## Problem

`getNumWarnings()` returns the value of a `ThreadLocal<Integer>` that is only assigned inside `parseContent()`:

```java
private ThreadLocal<Integer> _numWarningsDuringLastParse = new ThreadLocal<>();
...
public int getNumWarnings() {
    return _numWarningsDuringLastParse.get();   // auto-unboxing null -> NPE
}
```

If `getNumWarnings()` is called on a parser (or thread) that has not yet parsed a robots.txt file, `get()` returns `null` and auto-unboxing to `int` throws a `NullPointerException`.

## Fix

Initialize the `ThreadLocal` with `ThreadLocal.withInitial(() -> 0)` so it returns `0` before the first parse instead of `null`.

## Tests

Added `testGetNumWarningsBeforeParse`. Full `SimpleRobotRulesParserTest` suite passes (233 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)