### PR TITLE
[Robots] Add unit tests to verify that group merging and extension data

### DIFF
--- a/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
+++ b/src/test/java/crawlercommons/robots/SimpleRobotRulesParserTest.java
@@ -1495,6 +1495,82 @@ public class SimpleRobotRulesParserTest {
         assertEquals("10/1m", data.getValues().get(0));
     }
 
+    /**
+     * Test the combination of merging rule groups and the Crawl-delay extension.
+     *
+     * @throws Exception
+     */
+    @Test
+    void testCrawlDelayGroupMerging() throws Exception {
+        byte[] robotstxt = readFile("/robots/crawl-delay-group-merging.txt");
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("mybot"));
+        assertEquals(10000, rules.getCrawlDelay());
+        assertFalse(rules.isAllowed("https://example.com/private/"), "explicitely disallowed");
+        assertTrue(rules.isAllowed("https://example.com/login/"), "implicitely allowed");
+        assertTrue(rules.isAllowed("https://example.com/"), "implicitely allowed");
+
+        rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("yourbot"));
+        assertEquals(Long.MIN_VALUE, rules.getCrawlDelay()); // not defined
+        assertFalse(rules.isAllowed("https://example.com/private/"), "explicitely disallowed");
+        assertFalse(rules.isAllowed("https://example.com/login/"), "explicitely disallowed");
+        assertTrue(rules.isAllowed("https://example.com/"), "implicitely allowed");
+
+        rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("anyotherbot"));
+        assertEquals(30000, rules.getCrawlDelay());
+        assertTrue(rules.isAllowed("https://example.com/private/"), "implicitely allowed");
+        assertTrue(rules.isAllowed("https://example.com/login/"), "implicitely allowed");
+        assertTrue(rules.isAllowed("https://example.com/"), "explicitely allowed");
+    }
+
+    @Test
+    void testExtensionsGroupMerging() throws Exception {
+        byte[] robotstxt = readFile("/robots/extensions-group-merging.txt");
+
+        SimpleRobotRulesParser robotParser = new SimpleRobotRulesParser();
+        robotParser.enableAllExtensions();
+
+        SimpleRobotRules rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("mybot"));
+        // TODO: Visit-time leaks from wild-card user-agent, see #590
+        // assertEquals(3, rules.getExtensions().size(), "Content-Signal (global scope), Request-rate and Clean-param");
+        RobotsExtensionData data = rules.getExtensionData(RobotsExtension.CONTENT_SIGNALS);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("search=yes,ai-train=yes,ai-input=yes", data.getValues().get(0));
+        data = rules.getExtensionData(RobotsExtension.REQUEST_RATE);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("10/1m", data.getValues().get(0));
+        data = rules.getExtensionData(RobotsExtension.CLEAN_PARAM);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("utm_source /", data.getValues().get(0));
+        assertFalse(rules.isAllowed("https://example.com/private/"), "explicitely disallowed");
+        assertFalse(rules.isAllowed("https://example.com/login/"), "explicitely disallowed as part of a rule group");
+        assertTrue(rules.isAllowed("https://example.com/"), "implicitely allowed");
+
+        rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("yourbot"));
+        // TODO: Visit-time leaks from wild-card user-agent, see #590
+        // assertEquals(1, rules.getExtensions().size(), "Content-Signal (global scope)");
+        assertNotNull(rules.getExtensionData(RobotsExtension.CONTENT_SIGNALS));
+        assertFalse(rules.isAllowed("https://example.com/private/"), "explicitely disallowed");
+        assertFalse(rules.isAllowed("https://example.com/login/"), "explicitely disallowed");
+        assertTrue(rules.isAllowed("https://example.com/"), "implicitely allowed");
+
+        rules = robotParser.parseContent(FAKE_ROBOTS_URL, robotstxt, "text/plain", Set.of("anyotherbot"));
+        assertEquals(3, rules.getExtensions().size(), "Content-Signal, Visit-time and Request-rate");
+        assertNotNull(rules.getExtensionData(RobotsExtension.CONTENT_SIGNALS));
+        data = rules.getExtensionData(RobotsExtension.VISIT_TIME);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("0600-0845", data.getValues().get(0));
+        data = rules.getExtensionData(RobotsExtension.REQUEST_RATE);
+        assertNotNull(data, "Per-group extension should be captured for matched group");
+        assertEquals("30/1m", data.getValues().get(0));
+        assertFalse(rules.isAllowed("https://example.com/private/"), "implicitely disallowed");
+        assertFalse(rules.isAllowed("https://example.com/login/"), "implicitely disallowed");
+        assertFalse(rules.isAllowed("https://example.com/"), "explicitely disallowed");
+        assertTrue(rules.isAllowed("https://example.com/llms.txt"), "explicitely allowed");
+    }
+
     @Test
     void testExtensionPerGroupNotLeakedFromWildcard() {
         // Per-group extension values collected under the wildcard group must

--- a/src/test/resources/robots/crawl-delay-group-merging.txt
+++ b/src/test/resources/robots/crawl-delay-group-merging.txt
@@ -1,0 +1,30 @@
+# Crawl-delay extension and merging of robots.txt groups
+#
+# RFC 9309, section 2.2.1. The User-Agent Line
+# https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.1
+# Figure 2: Example of how to merge two robots.txt groups that match the same product token
+#
+# RFC 9309, section 2.2.4. Other Records
+# https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.4
+# "Parsing of other records MUST NOT interfere with the parsing of explicitly defined records in Section 2.
+#  For example, a "Sitemaps" record MUST NOT terminate a group."
+#
+# Also the Crawl-delay directive must not interfer with rule assignment.
+#
+# Unlike the Sitemaps directive, which has a global scope,
+# the Crawl-delay directives are assigned to individual user-agents.
+
+User-agent: mybot
+Crawl-delay: 10
+User-agent: yourbot
+Disallow: /private/  # Per RFC9309 (group merging): applies to mybot and yourbot
+
+User-agent: *
+Allow: /
+
+User-agent: yourbot
+Disallow: /login/    # Per RFC9309 (group merging): applies to mybot and yourbot
+
+User-agent: *
+Crawl-delay: 30
+

--- a/src/test/resources/robots/extensions-group-merging.txt
+++ b/src/test/resources/robots/extensions-group-merging.txt
@@ -1,0 +1,31 @@
+# Robots.txt extension and merging of robots.txt groups
+# cf. crawl-delay-group-merging.txt
+#
+# Most extensions are directed to a single user-agent (group).
+# However, some extensions (e.g., the sitemap directive) have
+# a global scope and apply to all user-agents.
+
+Content-Signal: search=yes,ai-train=yes,ai-input=yes  # global scope, affects all user-agents
+
+User-agent: *
+Allow: /llms.txt
+Visit-time: 0600-0845
+
+User-agent: mybot
+Request-rate: 10/1m
+User-agent: yourbot
+Disallow: /private/  # Per RFC9309 (group merging): applies to mybot and yourbot
+
+User-agent: *
+Disallow: /
+
+User-agent: mybot
+Clean-Param: utm_source /
+
+User-agent: yourbot
+Disallow: /login/    # Per RFC9309 (group merging): applies to mybot and yourbot
+
+User-agent: *
+Request-rate: 30/1m
+
+


### PR DESCRIPTION
The robots.txt parser tests lack unit tests which verify that
- extension data from multiple robots.txt rule groups is merged,
- the Crawl-delay is properly assigned to a single user-agent, even if there are multiple rule groups for this user-agent,
- and the extensions do not interfere with the merging of allow/disallow rules.

Merging of groups is described in [RFC 9309, section 2.2.1](https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.1):
> If there is more than one group matching the user-agent, the matching groups' rules MUST be combined into one group

Extensions to the robots.txt are mentioned [section 2.2.4 "Other Records"](https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2.4) with the requirement that it does not terminate groups:
> Parsing of other records MUST NOT interfere with the parsing of explicitly defined records in [Section 2](https://www.rfc-editor.org/rfc/rfc9309.html#specification). For example, a "Sitemaps" record MUST NOT terminate a group.

Because RFC 9309 does not define extensions, it does not tell anything about their scope and how extensions from multiple rule groups are to be merged. Nevertheless, group merging should obviously also apply for extensions, e.g.

```
User-agent: ExampleBot
Crawl-delay: 10
allow: /

user-agent: *
disallow: /search
disallow: /login/

user-agent: ExampleBot
Clean-param: sessionid
disallow: /login/
```

Note: the tests are affected by #590 and need to be updated after rebase.