### PR TITLE
[Robots.txt] Remove dead catch blocks around path normalization

### DIFF
--- a/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
+++ b/src/main/java/crawlercommons/robots/SimpleRobotRulesParser.java
@@ -1128,30 +1128,24 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             return;
         }
 
-        String path = token.getData();
-
-        try {
-            path = normalizePathDirective(path);
-            if (path.length() == 0) {
-                /*
-                 * "Disallow: <nothing>" meant "allow all" in the 1996 REP RFC
-                 * draft because there was no "Allow" directive.
-                 * 
-                 * RFC 9309 allows empty patterns in the formal syntax
-                 * (https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2). No
-                 * specific handling of empty patterns is defined, as shortest
-                 * pattern they are matched with lowest priority.
-                 * 
-                 * Adding an extra rule with an empty pattern would have no
-                 * effect, because an "allow all" with lowest priority means
-                 * "allow everything else" which is the default anyway. So, we
-                 * ignore the empty disallow statement.
-                 */
-            } else {
-                state.addRule(path, false);
-            }
-        } catch (Exception e) {
-            reportWarning(state, "Error parsing robots rules - can't decode path: {}", path);
+        String path = normalizePathDirective(token.getData());
+        if (path.length() == 0) {
+            /*
+             * "Disallow: <nothing>" meant "allow all" in the 1996 REP RFC draft
+             * because there was no "Allow" directive.
+             *
+             * RFC 9309 allows empty patterns in the formal syntax
+             * (https://www.rfc-editor.org/rfc/rfc9309.html#section-2.2). No
+             * specific handling of empty patterns is defined, as shortest
+             * pattern they are matched with lowest priority.
+             *
+             * Adding an extra rule with an empty pattern would have no effect,
+             * because an "allow all" with lowest priority means "allow
+             * everything else" which is the default anyway. So, we ignore the
+             * empty disallow statement.
+             */
+        } else {
+            state.addRule(path, false);
         }
     }
 
@@ -1168,18 +1162,11 @@ public class SimpleRobotRulesParser extends BaseRobotsParser {
             return;
         }
 
-        String path = token.getData();
-
-        try {
-            path = normalizePathDirective(path);
-        } catch (Exception e) {
-            reportWarning(state, "Error parsing robots rules - can't decode path: {}", path);
-        }
-
+        String path = normalizePathDirective(token.getData());
         if (path.length() == 0) {
             /*
              * Allow: <nothing> => allow all.
-             * 
+             *
              * See handleDisallow(...): We ignore the empty allow statement.
              */
         } else {


### PR DESCRIPTION
## Summary

`handleDisallow()` and `handleAllow()` in `SimpleRobotRulesParser` each wrapped the call to `normalizePathDirective()` in a `try/catch (Exception)` that logged `"Error parsing robots rules - can't decode path"`. These catch blocks are dead code and are removed here.

See #591 

## Why the catch existed

The catch was needed when the path was decoded with `URLDecoder.decode(path, "UTF-8")`, which throws `IllegalArgumentException` on malformed percent-escapes — a common occurrence in real-world robots.txt files. The catch turned that crash into a logged warning.

## Why it is now unreachable

`URLDecoder.decode` was replaced (commit 9559134) by:

`normalizePathDirective()` → `SimpleRobotRules.escapePath()` → `BasicURLNormalizer.escapePath(unescapePath(...))`

None of these can throw:

- `unescapePath` only matches the regex `%([0-9A-Fa-f]{2})`, so `Integer.valueOf(group, 16)` always sees two hex digits (≤ 0xFF) and never throws; all `StringBuilder` indices stay in range.
- `escapePath` does tolerant byte manipulation (e.g. a stray `%` is emitted as `%25`).
- `addRule` only appends to a list.

The catch has therefore been unreachable since that change, and its warning message references a decode step that no longer exists.

## Change

Unwrap the `try/catch` in both handlers. **No behavior change.**

## Testing

`SimpleRobotRulesParserTest` — 234 tests, all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)