### PR TITLE
Fix BasicURLNormalizer rejecting URLs with an IPv6 address as host name (#587)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 Crawler-Commons Change Log
 
 Current Development 1.7-SNAPSHOT (yyyy-mm-dd)
+- BasicURLNormalizer rejects URLs with IPv6 address as host name (Richard Zowalla, sebastian-nagel) #587
 - [Robots.txt] Remove dead catch blocks around path normalization (jnioche) #596
 - [Robots.txt] Fix typo in "Content-Signal" extension directive (sebastian-nagel) #595
 - [Robots.txt] Replace per-line directive-prefix scan in tokenize() with a prefix trie (jnioche) #593

--- a/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
+++ b/src/main/java/crawlercommons/filters/basic/BasicURLNormalizer.java
@@ -186,7 +186,7 @@ public class BasicURLNormalizer extends URLFilter {
         }
 
         // escape to ensure URL does not contain illegal characters
-        urlString = escapePath(urlString);
+        urlString = escapeUrlString(urlString);
 
         // Wrap the parsed URL in a CrawlerURL (issue #556) so the alternate
         // representations and components are obtained through a single,
@@ -595,6 +595,53 @@ public class BasicURLNormalizer extends URLFilter {
     }
 
     /**
+     * Escape a complete URL string, leaving a bracketed IPv6 literal in the
+     * authority component untouched.
+     * <p>
+     * The square brackets enclosing an IPv6 address are reserved delimiters (<a
+     * href="https://tools.ietf.org/html/rfc3986#section-3.2.2">RFC3986, section
+     * 3.2.2</a>) and must not be percent-encoded: escaping them turns a valid
+     * host such as {@code [::1]} into {@code %5B::1%5D}, which is then rejected
+     * as a malformed URL (issue #587). Everything outside the IPv6 literal is
+     * escaped by {@link #escapePath(String)} as before.
+     */
+    private static String escapeUrlString(String urlString) {
+        int hostStart = urlString.indexOf("://");
+        if (hostStart < 0) {
+            return escapePath(urlString);
+        }
+        hostStart += 3;
+
+        int authorityEnd = urlString.length();
+        for (int i = hostStart; i < authorityEnd; i++) {
+            char c = urlString.charAt(i);
+            if (c == '/' || c == '?') {
+                authorityEnd = i;
+                break;
+            }
+        }
+
+        // skip over the userinfo component, if present
+        int at = urlString.lastIndexOf('@', authorityEnd - 1);
+        if (at >= hostStart) {
+            hostStart = at + 1;
+        }
+
+        if (hostStart >= authorityEnd || urlString.charAt(hostStart) != '[') {
+            return escapePath(urlString);
+        }
+        int hostEnd = urlString.indexOf(']', hostStart);
+        if (hostEnd < 0 || hostEnd >= authorityEnd) {
+            // unbalanced bracket: not an IPv6 literal, escape as before
+            return escapePath(urlString);
+        }
+
+        return escapePath(urlString.substring(0, hostStart)) //
+                        + urlString.substring(hostStart, hostEnd + 1) //
+                        + escapePath(urlString.substring(hostEnd + 1));
+    }
+
+    /**
      * Convert path segment of URL from Unicode to UTF-8 and escape all
      * characters which should be escaped according to <a
      * href="https://tools.ietf.org/html/rfc3986#section-2.2">RFC3986</a>.
@@ -655,6 +702,21 @@ public class BasicURLNormalizer extends URLFilter {
     }
 
     private String normalizeHostName(String host) throws IllegalArgumentException, IndexOutOfBoundsException, UnsupportedEncodingException {
+
+        /*
+         * 0. IPv6 literal (issue #587): the address itself has already been
+         * validated by java.net.URI, only the hexadecimal digits need to be
+         * lowercased. None of the steps below apply: percent-encoding is not
+         * part of the IP-literal grammar (a percent sign can only introduce a
+         * zone identifier, which is not meaningful in a URL), and neither IDN
+         * mapping nor trailing-dot removal are defined for IP addresses.
+         */
+        if (host.startsWith("[") && host.endsWith("]")) {
+            if (host.indexOf('%') != -1) {
+                throw new IllegalArgumentException("Percent-encoding not allowed in IPv6 literal: " + host);
+            }
+            return host.toLowerCase(Locale.ROOT);
+        }
 
         /* 1. unescape percent-encoded characters in host name */
         if (host.indexOf('%') != -1) {

--- a/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
+++ b/src/test/java/crawlercommons/filters/basic/BasicURLNormalizerTest.java
@@ -79,6 +79,45 @@ public class BasicURLNormalizerTest {
         normalizeTest(url, urlNorm);
     }
 
+    /**
+     * Issue #587: the square brackets enclosing an IPv6 host are reserved
+     * delimiters and must survive escaping, otherwise the URL is rejected as
+     * malformed.
+     */
+    @ParameterizedTest
+    @CsvSource({ //
+                    "http://[::1]/,", //
+                    "http://[::1],http://[::1]/", //
+                    "http://[2001:db8::1]/path?q=1,", //
+                    // host is lowercased, default port is dropped
+                    "http://[2001:DB8::1]/,http://[2001:db8::1]/", //
+                    "http://[::1]:80/,http://[::1]/", //
+                    "https://[::1]:443/,https://[::1]/", //
+                    // non-default port is kept
+                    "http://[::1]:8080/x,", //
+                    // IPv4-mapped IPv6 address
+                    "http://[::ffff:127.0.0.1]/,", //
+                    // path normalization still applies
+                    "http://[::1]/a/../b,http://[::1]/b", //
+                    // userinfo is stripped as for any other host
+                    "http://user:pass@[::1]/x,http://[::1]/x", //
+                    // brackets outside the host are still escaped
+                    "http://example.com/[x],http://example.com/%5Bx%5D" })
+    public void testIPv6Host(String url, String urlNorm) {
+        normalizer = new BasicURLNormalizer();
+        normalizeTest(url, urlNorm == null ? url : urlNorm);
+    }
+
+    /** Issue #587: bracketed hosts which are not valid IPv6 literals. */
+    @ParameterizedTest
+    @CsvSource({ "http://[::1", "http://[]/", "http://[::1]./", //
+                    // percent-encoding is not part of the IP-literal grammar
+                    "http://[::%31]/" })
+    public void testInvalidIPv6Host(String url) {
+        normalizer = new BasicURLNormalizer();
+        assertNull(normalizer.filter(url), "normalizing: " + url);
+    }
+
     @Test
     public void testHostToUnicode() {
         normalizer = BasicURLNormalizer.newBuilder().idnNormalization(BasicURLNormalizer.IdnNormalization.UNICODE).build();

--- a/src/test/java/crawlercommons/utils/WptUrlNormalizationTest.java
+++ b/src/test/java/crawlercommons/utils/WptUrlNormalizationTest.java
@@ -107,10 +107,8 @@ public class WptUrlNormalizationTest {
         EXCLUSIONS.add("http://foo/abcd#foo?bar || http://example.org/foo/bar"); // WHATWG-divergence: crawler-commons drops the fragment component
         EXCLUSIONS.add("[61:24:74]:98 || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
         EXCLUSIONS.add("http:[61:27]/:foo || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal canonicalization differs
-        EXCLUSIONS.add("http://[2001::1] || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
-        EXCLUSIONS.add("http://[::127.0.0.1] || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
-        EXCLUSIONS.add("http://[0:0:0:0:0:0:13.1.68.3] || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
-        EXCLUSIONS.add("http://[2001::1]:80 || http://example.org/foo/bar"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
+        EXCLUSIONS.add("http://[::127.0.0.1] || http://example.org/foo/bar"); // WHATWG-divergence: embedded IPv4 in IPv6 literal not rewritten to hex groups
+        EXCLUSIONS.add("http://[0:0:0:0:0:0:13.1.68.3] || http://example.org/foo/bar"); // WHATWG-divergence: embedded IPv4 in IPv6 literal not rewritten to hex groups
         EXCLUSIONS.add("http:/example.com/ || http://example.org/foo/bar"); // WHATWG-divergence: relative/opaque scheme prefix resolved against base differently
         EXCLUSIONS.add("http:/ || http://example.com/"); // WHATWG-divergence: relative/opaque scheme prefix resolved against base differently
         EXCLUSIONS.add("https:/example.com/ || http://example.org/foo/bar"); // WHATWG-divergence: relative/opaque scheme prefix resolved against base differently
@@ -213,11 +211,9 @@ public class WptUrlNormalizationTest {
         EXCLUSIONS.add("https://0000000000000000000000000000000000000000177.0.0.1 || "); // WHATWG-divergence: WHATWG canonicalizes host to dotted-decimal IPv4; cc leaves as-is
         EXCLUSIONS.add("https://0x100000000/test || "); // WHATWG-divergence: WHATWG rejects invalid IPv4/host; Java URI accepts
         EXCLUSIONS.add("https://256.0.0.1/test || "); // WHATWG-divergence: WHATWG rejects invalid IPv4/host; Java URI accepts
-        EXCLUSIONS.add("http://[1:0::] || http://example.net/"); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
+        EXCLUSIONS.add("http://[1:0::] || http://example.net/"); // WHATWG-divergence: IPv6 literal zero-compression not canonicalized
         EXCLUSIONS.add("http://? || "); // WHATWG-divergence: empty host not rejected
         EXCLUSIONS.add("http://# || "); // WHATWG-divergence: empty host not rejected
-        EXCLUSIONS.add("http://[0:1:0:1:0:1:0:1] || "); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
-        EXCLUSIONS.add("http://[1:0:1:0:1:0:1:0] || "); // WHATWG-divergence: IPv6 literal parsing/compression; Java URI rejects
         EXCLUSIONS.add("http://example.org/test?\" || "); // WHATWG-divergence: WHATWG percent-encodes forbidden chars in path/query/fragment; Java URI rejects
         EXCLUSIONS.add("http://example.org/test?# || "); // WHATWG-divergence: crawler-commons drops the fragment component
         EXCLUSIONS.add("http://example.org/test?< || "); // WHATWG-divergence: WHATWG percent-encodes forbidden chars in path/query/fragment; Java URI rejects


### PR DESCRIPTION
Fixes #587.

filter() escaped the whole URL string via escapePath(), which percent-encodes [ and ]. An IPv6 host was mangled into http://%5B::1%5D/ and subsequently rejected as malformed.